### PR TITLE
Switch To Cryptographic Node Identifiers

### DIFF
--- a/datacake-cluster/Cargo.toml
+++ b/datacake-cluster/Cargo.toml
@@ -37,6 +37,9 @@ rkyv = { version = "0.7.9", features = ["validation"] }
 
 datacake-crdt = { path = "../datacake-crdt", version = "0.3", features = ["rkyv-support"] }
 
+age = "0.9"
+
+
 [features]
 test-utils = []
 

--- a/datacake-cluster/Cargo.toml
+++ b/datacake-cluster/Cargo.toml
@@ -38,6 +38,10 @@ rkyv = { version = "0.7.9", features = ["validation"] }
 datacake-crdt = { path = "../datacake-crdt", version = "0.3", features = ["rkyv-support"] }
 
 age = {version = "0.9", features = ["async"]}
+zeroize = "1"
+x25519-dalek = "1"
+[dependencies.bech32]
+version = "0.9"
 
 
 [features]

--- a/datacake-cluster/Cargo.toml
+++ b/datacake-cluster/Cargo.toml
@@ -37,7 +37,7 @@ rkyv = { version = "0.7.9", features = ["validation"] }
 
 datacake-crdt = { path = "../datacake-crdt", version = "0.3", features = ["rkyv-support"] }
 
-age = "0.9"
+age = {version = "0.9", features = ["async"]}
 
 
 [features]

--- a/datacake-cluster/src/node.rs
+++ b/datacake-cluster/src/node.rs
@@ -1,5 +1,4 @@
 use std::error::Error;
-use std::fmt::Debug;
 use std::net::SocketAddr;
 use std::str::FromStr;
 use std::sync::atomic::{AtomicBool, Ordering};
@@ -20,7 +19,7 @@ use tokio_stream::wrappers::WatchStream;
 use tokio_stream::StreamExt;
 
 use crate::error::DatacakeError;
-use crate::node_identifier::{NodeID, NodeIdentifier};
+use crate::node_identifier::NodeID;
 use crate::{ClusterStatistics, DEFAULT_DATA_CENTER};
 
 static DATA_CENTER_KEY: &str = "data_center";

--- a/datacake-cluster/src/node.rs
+++ b/datacake-cluster/src/node.rs
@@ -20,7 +20,7 @@ use tokio_stream::wrappers::WatchStream;
 use tokio_stream::StreamExt;
 
 use crate::error::DatacakeError;
-use crate::node_identifier::{NodeIdentifier, NodeID};
+use crate::node_identifier::{NodeID, NodeIdentifier};
 use crate::{ClusterStatistics, DEFAULT_DATA_CENTER};
 
 static DATA_CENTER_KEY: &str = "data_center";
@@ -33,7 +33,7 @@ const GOSSIP_INTERVAL: Duration = if cfg!(test) {
 #[derive(Clone, Eq, PartialEq)]
 pub struct ClusterMember {
     /// A unique ID for the given node in the cluster.
-    /// 
+    ///
     /// this is the node's age public key
     pub node_id: NodeID,
     /// The public address of the nod.
@@ -269,7 +269,12 @@ mod tests {
         let _ = tracing_subscriber::fmt::try_init();
 
         let transport = ChannelTransport::default();
-        let cluster = create_node_for_test(age::x25519::Identity::generate(), Vec::new(), &transport).await?;
+        let cluster = create_node_for_test(
+            age::x25519::Identity::generate(),
+            Vec::new(),
+            &transport,
+        )
+        .await?;
 
         let members: Vec<SocketAddr> = cluster
             .members()
@@ -287,11 +292,25 @@ mod tests {
         let _ = tracing_subscriber::fmt::try_init();
 
         let transport = ChannelTransport::default();
-        let node1 = create_node_for_test(age::x25519::Identity::generate(), Vec::new(), &transport).await?;
+        let node1 = create_node_for_test(
+            age::x25519::Identity::generate(),
+            Vec::new(),
+            &transport,
+        )
+        .await?;
         let node_1_gossip_addr = node1.public_addr.to_string();
-        let node2 =
-            create_node_for_test(age::x25519::Identity::generate(), vec![node_1_gossip_addr.clone()], &transport).await?;
-        let node3 = create_node_for_test(age::x25519::Identity::generate(), vec![node_1_gossip_addr], &transport).await?;
+        let node2 = create_node_for_test(
+            age::x25519::Identity::generate(),
+            vec![node_1_gossip_addr.clone()],
+            &transport,
+        )
+        .await?;
+        let node3 = create_node_for_test(
+            age::x25519::Identity::generate(),
+            vec![node_1_gossip_addr],
+            &transport,
+        )
+        .await?;
 
         let wait_secs = Duration::from_secs(30);
         for cluster in [&node1, &node2, &node3] {
@@ -361,13 +380,12 @@ mod tests {
     }
 }
 
-
 impl std::fmt::Debug for ClusterMember {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("ClusterMember")
-        .field("node_id", &self.chitchat_id())
-        .field("public_addr", &self.public_addr)
-        .field("data_center", &self.data_center)
-        .finish()
+            .field("node_id", &self.chitchat_id())
+            .field("public_addr", &self.public_addr)
+            .field("data_center", &self.data_center)
+            .finish()
     }
 }

--- a/datacake-cluster/src/node_identifier.rs
+++ b/datacake-cluster/src/node_identifier.rs
@@ -1,0 +1,135 @@
+use std::str::FromStr;
+
+use age::secrecy::ExposeSecret;
+use bech32::ToBase32;
+use x25519_dalek::{StaticSecret as SecretKey, PublicKey};
+use zeroize::Zeroize;
+
+
+/// the X25519 private key bytes as extracted from the rage keypair
+pub struct ExtractedRageX25519Secret([u8; 32]);
+
+/// Provides a cryptographic identifier for datacake cluster members which of
+/// the age crypto system. the rage keypair identifier is used as the node identifier
+/// and then broken down into the underlying X25519 secret and public keys.
+/// 
+/// This allows us to leverage both the larger dalek x25519 ecosystem of crates, while
+/// utilizing rage for easy multi-member encrypted messaging
+#[derive(Clone, Copy)]
+pub struct NodeIdentifier {
+    /// the x25519 private key extracted from the rage keypair
+    secret_key: [u8; 32],
+    /// the secret key's corresponding public key
+    public_key: [u8; 32],
+    /// the node identifier which is the rage public key itself
+    id: [u8; 62],
+}
+
+
+impl NodeIdentifier {
+    pub fn new(id: age::x25519::Identity) -> anyhow::Result<Self> {
+        Ok(TryFrom::try_from(id)?)
+    }
+    pub fn keypair(&self) -> (SecretKey, PublicKey) {
+        let pub_key = PublicKey::from(self.public_key);
+        let sec_key = SecretKey::from(self.secret_key);
+        (sec_key, pub_key)
+    }
+    pub fn rage_id(&self) -> String {
+        // wont ever fail
+        String::from_utf8(self.id.to_vec()).unwrap()
+    }
+    pub fn id(&self) -> anyhow::Result<age::x25519::Identity> {
+        ExtractedRageX25519Secret(self.secret_key).to_identity()
+    }
+}
+
+
+impl TryFrom<age::x25519::Identity> for NodeIdentifier {
+    type Error = anyhow::Error;
+    fn try_from(id: age::x25519::Identity) -> Result<Self, Self::Error> {
+        let node_id = {
+            let mut buffer: [u8; 62] = [0_u8; 62];
+            let public_key = id.to_public().to_string();
+            buffer.copy_from_slice(&public_key.as_bytes()[..]);
+            buffer
+        };
+        let extracted_id = strip_rage_identity(id)?;
+        let sk = SecretKey::from(extracted_id.0);
+        let pk = PublicKey::from(&sk);
+        
+        Ok(Self {
+            public_key: pk.to_bytes(),
+            secret_key: sk.to_bytes(),
+            id: node_id
+        })
+    }
+}
+
+
+impl TryFrom<ExtractedRageX25519Secret> for age::x25519::Identity {
+    type Error = anyhow::Error;
+    fn try_from(value: ExtractedRageX25519Secret) -> Result<Self, Self::Error> {
+        Ok(value.to_identity()?)
+    }
+}
+
+pub fn strip_rage_identity(id: age::x25519::Identity) -> anyhow::Result<ExtractedRageX25519Secret> {
+    let mut debased = {
+        let mut secret = id.to_string().expose_secret().clone();
+        let (_, mut data, _) = bech32::decode(&secret)?;
+        let debased: Vec<u8> = bech32::FromBase32::from_base32(&data)?;
+        data.clear();
+        secret.zeroize();
+        debased
+    };
+    let ex_sec = {
+        let mut secret_key: [u8; 32] = [0_u8; 32];
+        secret_key.copy_from_slice(&debased[..]);
+        debased.zeroize();
+        ExtractedRageX25519Secret(secret_key)
+    };
+
+    
+    Ok(ex_sec)
+}
+
+
+impl ExtractedRageX25519Secret {
+    fn to_identity(&self) -> anyhow::Result<age::x25519::Identity> {
+        let mut encoded = bech32::encode("age-secret-key-", self.0.to_base32(), bech32::Variant::Bech32)?;
+        let id = age::x25519::Identity::from_str(&encoded);
+        
+        encoded.zeroize();
+
+        match id {
+            Ok(id) => Ok(id),
+            Err(err) => return Err(anyhow::anyhow!("failed to parse rage identity {:#?}", err))
+        }
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use age::secrecy::ExposeSecret;
+
+    use super::*;
+    #[test]
+    fn test_identity() {
+        let id = age::x25519::Identity::generate();
+
+        let node_id = NodeIdentifier::new(id.clone()).unwrap();
+
+        let parsed_id = node_id.id().unwrap();
+
+        assert_eq!(
+            id.to_string().expose_secret(),
+            parsed_id.to_string().expose_secret()
+        );
+        let parsed_id = strip_rage_identity(id.clone()).unwrap();
+
+
+        let got_id = parsed_id.to_identity().unwrap();
+        assert_eq!(id.to_public().to_string(), got_id.to_public().to_string());
+    }
+}

--- a/datacake-cluster/src/node_identifier.rs
+++ b/datacake-cluster/src/node_identifier.rs
@@ -2,9 +2,8 @@ use std::str::FromStr;
 
 use age::secrecy::ExposeSecret;
 use bech32::ToBase32;
-use x25519_dalek::{StaticSecret as SecretKey, PublicKey};
+use x25519_dalek::{PublicKey, StaticSecret as SecretKey};
 use zeroize::Zeroize;
-
 
 /// the X25519 private key bytes as extracted from the rage keypair
 pub struct ExtractedRageX25519Secret([u8; 32]);
@@ -15,7 +14,7 @@ pub struct NodeID(pub [u8; 62]);
 /// Provides a cryptographic identifier for datacake cluster members which of
 /// the age crypto system. the rage keypair identifier is used as the node identifier
 /// and then broken down into the underlying X25519 secret and public keys.
-/// 
+///
 /// This allows us to leverage both the larger dalek x25519 ecosystem of crates, while
 /// utilizing rage for easy multi-member encrypted messaging
 #[derive(Clone, Copy, PartialEq, Eq)]
@@ -27,7 +26,6 @@ pub struct NodeIdentifier {
     /// the node identifier which is the rage public key itself
     id: NodeID,
 }
-
 
 impl NodeIdentifier {
     pub fn new(id: age::x25519::Identity) -> anyhow::Result<Self> {
@@ -44,15 +42,20 @@ impl NodeIdentifier {
     pub fn id(&self) -> anyhow::Result<age::x25519::Identity> {
         ExtractedRageX25519Secret(self.secret_key).to_identity()
     }
-    pub fn id_inner(&self) -> [u8; 62] { self.id.0 } 
-    pub fn node_id(&self) -> NodeID { NodeID(self.id.0) } 
+    pub fn id_inner(&self) -> [u8; 62] {
+        self.id.0
+    }
+    pub fn node_id(&self) -> NodeID {
+        NodeID(self.id.0)
+    }
 }
-
 
 impl FromStr for NodeID {
     type Err = anyhow::Error;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        if s.len() != 62 { return Err(anyhow::anyhow!("incorrect data length"))}
+        if s.len() != 62 {
+            return Err(anyhow::anyhow!("incorrect data length"));
+        }
         let mut buffer: [u8; 62] = [0_u8; 62];
         buffer.copy_from_slice(&s.as_bytes()[..]);
         Ok(Self(buffer))
@@ -89,15 +92,14 @@ impl TryFrom<age::x25519::Identity> for NodeIdentifier {
         let extracted_id = strip_rage_identity(id)?;
         let sk = SecretKey::from(extracted_id.0);
         let pk = PublicKey::from(&sk);
-        
+
         Ok(Self {
             public_key: pk.to_bytes(),
             secret_key: sk.to_bytes(),
-            id: NodeID(node_id)
+            id: NodeID(node_id),
         })
     }
 }
-
 
 impl TryFrom<ExtractedRageX25519Secret> for age::x25519::Identity {
     type Error = anyhow::Error;
@@ -106,7 +108,9 @@ impl TryFrom<ExtractedRageX25519Secret> for age::x25519::Identity {
     }
 }
 
-pub fn strip_rage_identity(id: age::x25519::Identity) -> anyhow::Result<ExtractedRageX25519Secret> {
+pub fn strip_rage_identity(
+    id: age::x25519::Identity,
+) -> anyhow::Result<ExtractedRageX25519Secret> {
     let mut debased = {
         let mut secret = id.to_string().expose_secret().clone();
         let (_, mut data, _) = bech32::decode(&secret)?;
@@ -122,21 +126,25 @@ pub fn strip_rage_identity(id: age::x25519::Identity) -> anyhow::Result<Extracte
         ExtractedRageX25519Secret(secret_key)
     };
 
-    
     Ok(ex_sec)
 }
 
-
 impl ExtractedRageX25519Secret {
     fn to_identity(&self) -> anyhow::Result<age::x25519::Identity> {
-        let mut encoded = bech32::encode("age-secret-key-", self.0.to_base32(), bech32::Variant::Bech32)?;
+        let mut encoded = bech32::encode(
+            "age-secret-key-",
+            self.0.to_base32(),
+            bech32::Variant::Bech32,
+        )?;
         let id = age::x25519::Identity::from_str(&encoded);
-        
+
         encoded.zeroize();
 
         match id {
             Ok(id) => Ok(id),
-            Err(err) => return Err(anyhow::anyhow!("failed to parse rage identity {:#?}", err))
+            Err(err) => {
+                return Err(anyhow::anyhow!("failed to parse rage identity {:#?}", err))
+            },
         }
     }
 }
@@ -174,7 +182,6 @@ mod test {
             parsed_id.to_string().expose_secret()
         );
         let parsed_id = strip_rage_identity(id.clone()).unwrap();
-
 
         let got_id = parsed_id.to_identity().unwrap();
         assert_eq!(id.to_public().to_string(), got_id.to_public().to_string());

--- a/datacake-cluster/src/node_identifier.rs
+++ b/datacake-cluster/src/node_identifier.rs
@@ -9,20 +9,23 @@ use zeroize::Zeroize;
 /// the X25519 private key bytes as extracted from the rage keypair
 pub struct ExtractedRageX25519Secret([u8; 32]);
 
+#[derive(Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
+pub struct NodeID(pub [u8; 62]);
+
 /// Provides a cryptographic identifier for datacake cluster members which of
 /// the age crypto system. the rage keypair identifier is used as the node identifier
 /// and then broken down into the underlying X25519 secret and public keys.
 /// 
 /// This allows us to leverage both the larger dalek x25519 ecosystem of crates, while
 /// utilizing rage for easy multi-member encrypted messaging
-#[derive(Clone, Copy)]
+#[derive(Clone, Copy, PartialEq, Eq)]
 pub struct NodeIdentifier {
     /// the x25519 private key extracted from the rage keypair
     secret_key: [u8; 32],
     /// the secret key's corresponding public key
     public_key: [u8; 32],
     /// the node identifier which is the rage public key itself
-    id: [u8; 62],
+    id: NodeID,
 }
 
 
@@ -36,14 +39,45 @@ impl NodeIdentifier {
         (sec_key, pub_key)
     }
     pub fn rage_id(&self) -> String {
-        // wont ever fail
-        String::from_utf8(self.id.to_vec()).unwrap()
+        self.id.to_string()
     }
     pub fn id(&self) -> anyhow::Result<age::x25519::Identity> {
         ExtractedRageX25519Secret(self.secret_key).to_identity()
     }
+    pub fn id_inner(&self) -> [u8; 62] { self.id.0 } 
+    pub fn node_id(&self) -> NodeID { NodeID(self.id.0) } 
 }
 
+
+impl FromStr for NodeID {
+    type Err = anyhow::Error;
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        if s.len() != 62 { return Err(anyhow::anyhow!("incorrect data length"))}
+        let mut buffer: [u8; 62] = [0_u8; 62];
+        buffer.copy_from_slice(&s.as_bytes()[..]);
+        Ok(Self(buffer))
+    }
+}
+
+impl ToString for NodeID {
+    fn to_string(&self) -> String {
+        String::from_utf8(self.0.to_vec()).unwrap()
+    }
+}
+
+impl std::fmt::Debug for NodeIdentifier {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("NodeIdentifier")
+        .field("id", &self.rage_id()).finish()
+    }
+}
+
+impl std::fmt::Display for NodeIdentifier {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("NodeIdentifier")
+        .field("id", &self.rage_id()).finish()
+    }
+}
 
 impl TryFrom<age::x25519::Identity> for NodeIdentifier {
     type Error = anyhow::Error;
@@ -61,7 +95,7 @@ impl TryFrom<age::x25519::Identity> for NodeIdentifier {
         Ok(Self {
             public_key: pk.to_bytes(),
             secret_key: sk.to_bytes(),
-            id: node_id
+            id: NodeID(node_id)
         })
     }
 }
@@ -106,6 +140,23 @@ impl ExtractedRageX25519Secret {
             Ok(id) => Ok(id),
             Err(err) => return Err(anyhow::anyhow!("failed to parse rage identity {:#?}", err))
         }
+    }
+}
+
+impl From<age::x25519::Recipient> for NodeID {
+    fn from(r: age::x25519::Recipient) -> Self {
+        let pub_key = r.to_string();
+        let mut identifier: [u8; 62] = [0_u8; 62];
+        identifier.copy_from_slice(&pub_key.as_bytes()[..]);
+        Self(identifier)
+    }
+}
+
+impl std::fmt::Debug for NodeID {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("NodeId")
+        .field("0", &self.0)
+        .finish()
     }
 }
 

--- a/datacake-cluster/src/node_identifier.rs
+++ b/datacake-cluster/src/node_identifier.rs
@@ -67,15 +67,13 @@ impl ToString for NodeID {
 
 impl std::fmt::Debug for NodeIdentifier {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.debug_struct("NodeIdentifier")
-        .field("id", &self.rage_id()).finish()
+        f.write_str(&self.rage_id())
     }
 }
 
 impl std::fmt::Display for NodeIdentifier {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.debug_struct("NodeIdentifier")
-        .field("id", &self.rage_id()).finish()
+        f.write_str(&self.rage_id())
     }
 }
 
@@ -154,9 +152,7 @@ impl From<age::x25519::Recipient> for NodeID {
 
 impl std::fmt::Debug for NodeID {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.debug_struct("NodeId")
-        .field("0", &self.0)
-        .finish()
+        f.write_str(&self.to_string())
     }
 }
 

--- a/datacake-cluster/src/node_identifier.rs
+++ b/datacake-cluster/src/node_identifier.rs
@@ -29,7 +29,7 @@ pub struct NodeIdentifier {
 
 impl NodeIdentifier {
     pub fn new(id: age::x25519::Identity) -> anyhow::Result<Self> {
-        Ok(TryFrom::try_from(id)?)
+        TryFrom::try_from(id)
     }
     pub fn keypair(&self) -> (SecretKey, PublicKey) {
         let pub_key = PublicKey::from(self.public_key);
@@ -57,7 +57,7 @@ impl FromStr for NodeID {
             return Err(anyhow::anyhow!("incorrect data length"));
         }
         let mut buffer: [u8; 62] = [0_u8; 62];
-        buffer.copy_from_slice(&s.as_bytes()[..]);
+        buffer.copy_from_slice(s.as_bytes());
         Ok(Self(buffer))
     }
 }
@@ -86,7 +86,7 @@ impl TryFrom<age::x25519::Identity> for NodeIdentifier {
         let node_id = {
             let mut buffer: [u8; 62] = [0_u8; 62];
             let public_key = id.to_public().to_string();
-            buffer.copy_from_slice(&public_key.as_bytes()[..]);
+            buffer.copy_from_slice(public_key.as_bytes());
             buffer
         };
         let extracted_id = strip_rage_identity(id)?;
@@ -104,7 +104,7 @@ impl TryFrom<age::x25519::Identity> for NodeIdentifier {
 impl TryFrom<ExtractedRageX25519Secret> for age::x25519::Identity {
     type Error = anyhow::Error;
     fn try_from(value: ExtractedRageX25519Secret) -> Result<Self, Self::Error> {
-        Ok(value.to_identity()?)
+        value.to_identity()
     }
 }
 
@@ -153,7 +153,7 @@ impl From<age::x25519::Recipient> for NodeID {
     fn from(r: age::x25519::Recipient) -> Self {
         let pub_key = r.to_string();
         let mut identifier: [u8; 62] = [0_u8; 62];
-        identifier.copy_from_slice(&pub_key.as_bytes()[..]);
+        identifier.copy_from_slice(pub_key.as_bytes());
         Self(identifier)
     }
 }

--- a/datacake-cluster/src/nodes_selector.rs
+++ b/datacake-cluster/src/nodes_selector.rs
@@ -26,7 +26,8 @@ where
     tokio::spawn(async move {
         let mut total_nodes = 0;
         let mut data_centers = BTreeMap::new();
-        let mut cached_nodes = HashMap::<Consistency, (Instant, Vec<(NodeID, SocketAddr)>)>::new();
+        let mut cached_nodes =
+            HashMap::<Consistency, (Instant, Vec<(NodeID, SocketAddr)>)>::new();
 
         while let Ok(op) = rx.recv_async().await {
             match op {
@@ -92,7 +93,7 @@ impl NodeSelectorHandle {
     /// Set the nodes which can be used by the selector.
     pub async fn set_nodes(
         &self,
-        data_centers: BTreeMap::<Cow<'static, str>, Vec<(NodeID, SocketAddr)>>,
+        data_centers: BTreeMap<Cow<'static, str>, Vec<(NodeID, SocketAddr)>>,
     ) {
         self.tx
             .send_async(Op::SetNodes { data_centers })
@@ -121,7 +122,7 @@ impl NodeSelectorHandle {
 
 enum Op {
     SetNodes {
-        data_centers: BTreeMap::<Cow<'static, str>, Vec<(NodeID, SocketAddr)>>,
+        data_centers: BTreeMap<Cow<'static, str>, Vec<(NodeID, SocketAddr)>>,
     },
     GetNodes {
         consistency: Consistency,
@@ -563,7 +564,10 @@ mod tests {
             .select_nodes(addr, "dc-0", total_nodes, &mut dc, Consistency::EachQuorum)
             .expect("Get nodes");
         assert_eq!(
-            nodes.iter().map(|(_, addr)| addr.clone()).collect::<Vec<_>>(),
+            nodes
+                .iter()
+                .map(|(_, addr)| addr.clone())
+                .collect::<Vec<_>>(),
             vec![
                 make_addr(0, 1),
                 make_addr(1, 0),
@@ -575,13 +579,22 @@ mod tests {
         let nodes = selector
             .select_nodes(addr, "dc-0", total_nodes, &mut dc, Consistency::LocalQuorum)
             .expect("Get nodes");
-        assert_eq!(nodes.iter().map(|(_, addr)| addr.clone()).collect::<Vec<_>>(), vec![make_addr(0, 1)]);
+        assert_eq!(
+            nodes
+                .iter()
+                .map(|(_, addr)| addr.clone())
+                .collect::<Vec<_>>(),
+            vec![make_addr(0, 1)]
+        );
 
         let nodes = selector
             .select_nodes(addr, "dc-0", total_nodes, &mut dc, Consistency::Quorum)
             .expect("Get nodes");
         assert_eq!(
-            nodes.iter().map(|(_, addr)| addr.clone()).collect::<Vec<_>>(),
+            nodes
+                .iter()
+                .map(|(_, addr)| addr.clone())
+                .collect::<Vec<_>>(),
             vec![make_addr(0, 1), make_addr(1, 0), make_addr(2, 0),]
         );
 
@@ -617,49 +630,94 @@ mod tests {
         let nodes =
             select_n_nodes(addr, "dc-0", 3, total_nodes, &mut dc).expect("get nodes");
         assert_eq!(
-            nodes.iter().map(|(_, addr)| addr.clone()).collect::<Vec<_>>(),
+            nodes
+                .iter()
+                .map(|(_, addr)| addr.clone())
+                .collect::<Vec<_>>(),
             vec![make_addr(1, 0), make_addr(1, 1), make_addr(2, 0),],
         );
 
         let nodes =
             select_n_nodes(addr, "dc-0", 2, total_nodes, &mut dc).expect("get nodes");
-        assert_eq!(nodes.iter().map(|(_, addr)| addr.clone()).collect::<Vec<_>>(), vec![make_addr(1, 0), make_addr(2, 0),],);
+        assert_eq!(
+            nodes
+                .iter()
+                .map(|(_, addr)| addr.clone())
+                .collect::<Vec<_>>(),
+            vec![make_addr(1, 0), make_addr(2, 0),],
+        );
 
         let nodes =
             select_n_nodes(addr, "dc-0", 0, total_nodes, &mut dc).expect("get nodes");
-        assert_eq!(nodes.iter().map(|(_, addr)| addr.clone()).collect::<Vec<_>>(), Vec::<SocketAddr>::new());
+        assert_eq!(
+            nodes
+                .iter()
+                .map(|(_, addr)| addr.clone())
+                .collect::<Vec<_>>(),
+            Vec::<SocketAddr>::new()
+        );
 
         // DC-1
         let nodes =
             select_n_nodes(addr, "dc-1", 3, total_nodes, &mut dc).expect("get nodes");
         assert_eq!(
-            nodes.iter().map(|(_, addr)| addr.clone()).collect::<Vec<_>>(),
+            nodes
+                .iter()
+                .map(|(_, addr)| addr.clone())
+                .collect::<Vec<_>>(),
             vec![make_addr(0, 1), make_addr(0, 2), make_addr(2, 0),],
         );
 
         let nodes =
             select_n_nodes(addr, "dc-1", 2, total_nodes, &mut dc).expect("get nodes");
-        assert_eq!(nodes.iter().map(|(_, addr)| addr.clone()).collect::<Vec<_>>(), vec![make_addr(0, 1), make_addr(2, 0),],);
+        assert_eq!(
+            nodes
+                .iter()
+                .map(|(_, addr)| addr.clone())
+                .collect::<Vec<_>>(),
+            vec![make_addr(0, 1), make_addr(2, 0),],
+        );
 
         let nodes =
             select_n_nodes(addr, "dc-1", 0, total_nodes, &mut dc).expect("get nodes");
-        assert_eq!(nodes.iter().map(|(_, addr)| addr.clone()).collect::<Vec<_>>(), Vec::<SocketAddr>::new());
+        assert_eq!(
+            nodes
+                .iter()
+                .map(|(_, addr)| addr.clone())
+                .collect::<Vec<_>>(),
+            Vec::<SocketAddr>::new()
+        );
 
         // DC-2
         let nodes =
             select_n_nodes(addr, "dc-2", 3, total_nodes, &mut dc).expect("get nodes");
         assert_eq!(
-            nodes.iter().map(|(_, addr)| addr.clone()).collect::<Vec<_>>(),
+            nodes
+                .iter()
+                .map(|(_, addr)| addr.clone())
+                .collect::<Vec<_>>(),
             vec![make_addr(0, 2), make_addr(0, 0), make_addr(1, 1),],
         );
 
         let nodes =
             select_n_nodes(addr, "dc-2", 2, total_nodes, &mut dc).expect("get nodes");
-        assert_eq!(nodes.iter().map(|(_, addr)| addr.clone()).collect::<Vec<_>>(), vec![make_addr(0, 1), make_addr(1, 0),],);
+        assert_eq!(
+            nodes
+                .iter()
+                .map(|(_, addr)| addr.clone())
+                .collect::<Vec<_>>(),
+            vec![make_addr(0, 1), make_addr(1, 0),],
+        );
 
         let nodes =
             select_n_nodes(addr, "dc-2", 0, total_nodes, &mut dc).expect("get nodes");
-        assert_eq!(nodes.iter().map(|(_, addr)| addr.clone()).collect::<Vec<_>>(), Vec::<SocketAddr>::new());
+        assert_eq!(
+            nodes
+                .iter()
+                .map(|(_, addr)| addr.clone())
+                .collect::<Vec<_>>(),
+            Vec::<SocketAddr>::new()
+        );
     }
 
     #[test]
@@ -672,17 +730,32 @@ mod tests {
         let nodes =
             select_n_nodes(addr, "dc-0", 3, total_nodes, &mut dc).expect("get nodes");
         assert_eq!(
-            nodes.iter().map(|(_, addr)| addr.clone()).collect::<Vec<_>>(),
+            nodes
+                .iter()
+                .map(|(_, addr)| addr.clone())
+                .collect::<Vec<_>>(),
             vec![make_addr(0, 1), make_addr(0, 2), make_addr(1, 0),],
         );
 
         let nodes =
             select_n_nodes(addr, "dc-0", 2, total_nodes, &mut dc).expect("get nodes");
-        assert_eq!(nodes.iter().map(|(_, addr)| addr.clone()).collect::<Vec<_>>(), vec![make_addr(1, 1), make_addr(1, 0),],);
+        assert_eq!(
+            nodes
+                .iter()
+                .map(|(_, addr)| addr.clone())
+                .collect::<Vec<_>>(),
+            vec![make_addr(1, 1), make_addr(1, 0),],
+        );
 
         let nodes =
             select_n_nodes(addr, "dc-0", 0, total_nodes, &mut dc).expect("get nodes");
-        assert_eq!(nodes.iter().map(|(_, addr)| addr.clone()).collect::<Vec<_>>(), Vec::<SocketAddr>::new());
+        assert_eq!(
+            nodes
+                .iter()
+                .map(|(_, addr)| addr.clone())
+                .collect::<Vec<_>>(),
+            Vec::<SocketAddr>::new()
+        );
     }
 
     fn make_dc(distribution: Vec<usize>) -> BTreeMap<Cow<'static, str>, NodeCycler> {
@@ -694,7 +767,12 @@ mod tests {
             for i in 0..num_nodes {
                 let addr = make_addr(dc_n as u8, i as u8);
                 // todo: decide how to set the node name here
-                nodes.push((NodeIdentifier::new(age::x25519::Identity::generate()).unwrap().node_id(), addr));
+                nodes.push((
+                    NodeIdentifier::new(age::x25519::Identity::generate())
+                        .unwrap()
+                        .node_id(),
+                    addr,
+                ));
             }
 
             dc.insert(name, NodeCycler::from(nodes));

--- a/datacake-cluster/src/nodes_selector.rs
+++ b/datacake-cluster/src/nodes_selector.rs
@@ -564,10 +564,7 @@ mod tests {
             .select_nodes(addr, "dc-0", total_nodes, &mut dc, Consistency::EachQuorum)
             .expect("Get nodes");
         assert_eq!(
-            nodes
-                .iter()
-                .map(|(_, addr)| addr.clone())
-                .collect::<Vec<_>>(),
+            nodes.iter().map(|(_, addr)| *addr).collect::<Vec<_>>(),
             vec![
                 make_addr(0, 1),
                 make_addr(1, 0),
@@ -580,10 +577,7 @@ mod tests {
             .select_nodes(addr, "dc-0", total_nodes, &mut dc, Consistency::LocalQuorum)
             .expect("Get nodes");
         assert_eq!(
-            nodes
-                .iter()
-                .map(|(_, addr)| addr.clone())
-                .collect::<Vec<_>>(),
+            nodes.iter().map(|(_, addr)| *addr).collect::<Vec<_>>(),
             vec![make_addr(0, 1)]
         );
 
@@ -591,10 +585,7 @@ mod tests {
             .select_nodes(addr, "dc-0", total_nodes, &mut dc, Consistency::Quorum)
             .expect("Get nodes");
         assert_eq!(
-            nodes
-                .iter()
-                .map(|(_, addr)| addr.clone())
-                .collect::<Vec<_>>(),
+            nodes.iter().map(|(_, addr)| *addr).collect::<Vec<_>>(),
             vec![make_addr(0, 1), make_addr(1, 0), make_addr(2, 0),]
         );
 
@@ -630,30 +621,21 @@ mod tests {
         let nodes =
             select_n_nodes(addr, "dc-0", 3, total_nodes, &mut dc).expect("get nodes");
         assert_eq!(
-            nodes
-                .iter()
-                .map(|(_, addr)| addr.clone())
-                .collect::<Vec<_>>(),
+            nodes.iter().map(|(_, addr)| *addr).collect::<Vec<_>>(),
             vec![make_addr(1, 0), make_addr(1, 1), make_addr(2, 0),],
         );
 
         let nodes =
             select_n_nodes(addr, "dc-0", 2, total_nodes, &mut dc).expect("get nodes");
         assert_eq!(
-            nodes
-                .iter()
-                .map(|(_, addr)| addr.clone())
-                .collect::<Vec<_>>(),
+            nodes.iter().map(|(_, addr)| *addr).collect::<Vec<_>>(),
             vec![make_addr(1, 0), make_addr(2, 0),],
         );
 
         let nodes =
             select_n_nodes(addr, "dc-0", 0, total_nodes, &mut dc).expect("get nodes");
         assert_eq!(
-            nodes
-                .iter()
-                .map(|(_, addr)| addr.clone())
-                .collect::<Vec<_>>(),
+            nodes.iter().map(|(_, addr)| *addr).collect::<Vec<_>>(),
             Vec::<SocketAddr>::new()
         );
 
@@ -661,30 +643,21 @@ mod tests {
         let nodes =
             select_n_nodes(addr, "dc-1", 3, total_nodes, &mut dc).expect("get nodes");
         assert_eq!(
-            nodes
-                .iter()
-                .map(|(_, addr)| addr.clone())
-                .collect::<Vec<_>>(),
+            nodes.iter().map(|(_, addr)| *addr).collect::<Vec<_>>(),
             vec![make_addr(0, 1), make_addr(0, 2), make_addr(2, 0),],
         );
 
         let nodes =
             select_n_nodes(addr, "dc-1", 2, total_nodes, &mut dc).expect("get nodes");
         assert_eq!(
-            nodes
-                .iter()
-                .map(|(_, addr)| addr.clone())
-                .collect::<Vec<_>>(),
+            nodes.iter().map(|(_, addr)| *addr).collect::<Vec<_>>(),
             vec![make_addr(0, 1), make_addr(2, 0),],
         );
 
         let nodes =
             select_n_nodes(addr, "dc-1", 0, total_nodes, &mut dc).expect("get nodes");
         assert_eq!(
-            nodes
-                .iter()
-                .map(|(_, addr)| addr.clone())
-                .collect::<Vec<_>>(),
+            nodes.iter().map(|(_, addr)| *addr).collect::<Vec<_>>(),
             Vec::<SocketAddr>::new()
         );
 
@@ -692,30 +665,21 @@ mod tests {
         let nodes =
             select_n_nodes(addr, "dc-2", 3, total_nodes, &mut dc).expect("get nodes");
         assert_eq!(
-            nodes
-                .iter()
-                .map(|(_, addr)| addr.clone())
-                .collect::<Vec<_>>(),
+            nodes.iter().map(|(_, addr)| *addr).collect::<Vec<_>>(),
             vec![make_addr(0, 2), make_addr(0, 0), make_addr(1, 1),],
         );
 
         let nodes =
             select_n_nodes(addr, "dc-2", 2, total_nodes, &mut dc).expect("get nodes");
         assert_eq!(
-            nodes
-                .iter()
-                .map(|(_, addr)| addr.clone())
-                .collect::<Vec<_>>(),
+            nodes.iter().map(|(_, addr)| *addr).collect::<Vec<_>>(),
             vec![make_addr(0, 1), make_addr(1, 0),],
         );
 
         let nodes =
             select_n_nodes(addr, "dc-2", 0, total_nodes, &mut dc).expect("get nodes");
         assert_eq!(
-            nodes
-                .iter()
-                .map(|(_, addr)| addr.clone())
-                .collect::<Vec<_>>(),
+            nodes.iter().map(|(_, addr)| *addr).collect::<Vec<_>>(),
             Vec::<SocketAddr>::new()
         );
     }
@@ -730,30 +694,21 @@ mod tests {
         let nodes =
             select_n_nodes(addr, "dc-0", 3, total_nodes, &mut dc).expect("get nodes");
         assert_eq!(
-            nodes
-                .iter()
-                .map(|(_, addr)| addr.clone())
-                .collect::<Vec<_>>(),
+            nodes.iter().map(|(_, addr)| *addr).collect::<Vec<_>>(),
             vec![make_addr(0, 1), make_addr(0, 2), make_addr(1, 0),],
         );
 
         let nodes =
             select_n_nodes(addr, "dc-0", 2, total_nodes, &mut dc).expect("get nodes");
         assert_eq!(
-            nodes
-                .iter()
-                .map(|(_, addr)| addr.clone())
-                .collect::<Vec<_>>(),
+            nodes.iter().map(|(_, addr)| *addr).collect::<Vec<_>>(),
             vec![make_addr(1, 1), make_addr(1, 0),],
         );
 
         let nodes =
             select_n_nodes(addr, "dc-0", 0, total_nodes, &mut dc).expect("get nodes");
         assert_eq!(
-            nodes
-                .iter()
-                .map(|(_, addr)| addr.clone())
-                .collect::<Vec<_>>(),
+            nodes.iter().map(|(_, addr)| *addr).collect::<Vec<_>>(),
             Vec::<SocketAddr>::new()
         );
     }

--- a/datacake-cluster/src/replication/distributor.rs
+++ b/datacake-cluster/src/replication/distributor.rs
@@ -214,7 +214,7 @@ async fn execute_batch(
     let limiter = Arc::new(Semaphore::new(MAX_CONCURRENT_REQUESTS));
     let mut tasks = Vec::with_capacity(live_members.len());
     for (node_id, &addr) in live_members {
-        let node_id = node_id.clone();
+        let node_id = *node_id;
         let limiter = limiter.clone();
         let batch = batch.clone();
         let channel = ctx.network.get_or_connect_lazy(addr);

--- a/datacake-cluster/src/replication/distributor.rs
+++ b/datacake-cluster/src/replication/distributor.rs
@@ -10,6 +10,7 @@ use datacake_crdt::{HLCTimestamp, Key, StateChanges};
 use tokio::sync::Semaphore;
 use tokio::time::{interval, MissedTickBehavior};
 
+use crate::node_identifier::NodeID;
 use crate::replication::{MembershipChanges, MAX_CONCURRENT_REQUESTS};
 use crate::rpc::datacake_api;
 use crate::rpc::datacake_api::Context;
@@ -121,7 +122,7 @@ async fn task_distributor_service(
             match task {
                 Op::MembershipChange(changes) => {
                     for node_id in changes.left {
-                        live_members.remove(node_id.as_ref());
+                        live_members.remove(&node_id);
                     }
 
                     for (node_id, addr) in changes.joined {
@@ -207,7 +208,7 @@ fn register_mutation(
 
 async fn execute_batch(
     ctx: &TaskServiceContext,
-    live_members: &BTreeMap<Cow<'static, str>, SocketAddr>,
+    live_members: &BTreeMap<NodeID, SocketAddr>,
     batch: datacake_api::BatchPayload,
 ) -> anyhow::Result<()> {
     let limiter = Arc::new(Semaphore::new(MAX_CONCURRENT_REQUESTS));
@@ -216,7 +217,7 @@ async fn execute_batch(
         let node_id = node_id.clone();
         let limiter = limiter.clone();
         let batch = batch.clone();
-        let channel = ctx.network.get_or_connect_lazy(Some(node_id.to_string()), addr);
+        let channel = ctx.network.get_or_connect_lazy(Some(node_id), addr);
         let mut client = ConsistencyClient::new(ctx.clock.clone(), channel);
 
         let task = tokio::spawn(async move {
@@ -232,7 +233,7 @@ async fn execute_batch(
         if let Err(e) = res {
             error!(
                 error = ?e,
-                target_node_id = %node_id,
+                target_node_id = %node_id.to_string(),
                 target_addr = %addr,
                 "Failed to synchronise node with batch events. This will resolved when the next replication cycle occurs.",
             );

--- a/datacake-cluster/src/replication/distributor.rs
+++ b/datacake-cluster/src/replication/distributor.rs
@@ -216,7 +216,7 @@ async fn execute_batch(
         let node_id = node_id.clone();
         let limiter = limiter.clone();
         let batch = batch.clone();
-        let channel = ctx.network.get_or_connect_lazy(addr);
+        let channel = ctx.network.get_or_connect_lazy(Some(node_id.to_string()), addr);
         let mut client = ConsistencyClient::new(ctx.clock.clone(), channel);
 
         let task = tokio::spawn(async move {

--- a/datacake-cluster/src/replication/distributor.rs
+++ b/datacake-cluster/src/replication/distributor.rs
@@ -24,7 +24,7 @@ pub struct TaskServiceContext {
     /// The network handle which contains all RPC connections.
     pub(crate) network: RpcNetwork,
     /// The unique ID of the node running.
-    pub(crate) local_node_id: Cow<'static, str>,
+    pub(crate) local_node_id: NodeID,
     /// The public RPC address of the node running.
     pub(crate) public_node_addr: SocketAddr,
 }
@@ -217,7 +217,7 @@ async fn execute_batch(
         let node_id = node_id.clone();
         let limiter = limiter.clone();
         let batch = batch.clone();
-        let channel = ctx.network.get_or_connect_lazy(Some(node_id), addr);
+        let channel = ctx.network.get_or_connect_lazy(addr);
         let mut client = ConsistencyClient::new(ctx.clock.clone(), channel);
 
         let task = tokio::spawn(async move {

--- a/datacake-cluster/src/replication/mod.rs
+++ b/datacake-cluster/src/replication/mod.rs
@@ -10,9 +10,9 @@ pub const MAX_CONCURRENT_REQUESTS: usize = 10;
 /// Represents a set of changes to the membership of the cluster.
 pub(crate) struct MembershipChanges {
     /// A set of nodes which have joined the cluster.
-    pub(crate) joined: Vec<(Cow<'static, str>, SocketAddr)>,
+    pub(crate) joined: Vec<(NodeID, SocketAddr)>,
     /// A set of nodes which have left the cluster.
-    pub(crate) left: Vec<Cow<'static, str>>,
+    pub(crate) left: Vec<NodeID>,
 }
 
 pub(crate) use distributor::{
@@ -26,3 +26,5 @@ pub(crate) use poller::{
     ReplicationCycleContext,
     ReplicationHandle,
 };
+
+use crate::node_identifier::NodeID;

--- a/datacake-cluster/src/replication/mod.rs
+++ b/datacake-cluster/src/replication/mod.rs
@@ -1,7 +1,6 @@
 mod distributor;
 mod poller;
 
-use std::borrow::Cow;
 use std::net::SocketAddr;
 
 pub const MAX_CONCURRENT_REQUESTS: usize = 10;

--- a/datacake-cluster/src/replication/poller.rs
+++ b/datacake-cluster/src/replication/poller.rs
@@ -259,7 +259,7 @@ where
         "Getting keyspace changes on remote node.",
     );
 
-    let channel = ctx.network.get_or_connect(target_node_addr).await?;
+    let channel = ctx.network.get_or_connect(Some(target_node_id.clone()), target_node_addr).await?;
     let mut client = ReplicationClient::new(ctx.clock().clone(), channel.clone());
     let keyspace_timestamps = client.poll_keyspace().await?;
 
@@ -386,7 +386,7 @@ async fn begin_keyspace_sync<S>(
 where
     S: Storage + Send + Sync + 'static,
 {
-    let channel = ctx.network.get_or_connect(target_rpc_addr).await?;
+    let channel = ctx.network.get_or_connect(Some(target_node_id.clone()), target_rpc_addr).await?;
     let keyspace = ctx.group.get_or_create_keyspace(&keyspace_name).await;
     let client = ReplicationClient::new(ctx.clock().clone(), channel.clone());
 

--- a/datacake-cluster/src/replication/poller.rs
+++ b/datacake-cluster/src/replication/poller.rs
@@ -193,8 +193,7 @@ async fn read_repair_members<S>(
     S: Storage + Send + Sync + 'static,
 {
     for (node_id, addr) in live_members {
-        let res =
-            check_node_changes(ctx, *node_id, *addr, keyspace_tracker).await;
+        let res = check_node_changes(ctx, *node_id, *addr, keyspace_tracker).await;
 
         let info = match res {
             Err(e) => {
@@ -260,7 +259,7 @@ where
         "Getting keyspace changes on remote node.",
     );
 
-    let channel = ctx.network.get_or_connect(Some(target_node_id), target_node_addr).await?;
+    let channel = ctx.network.get_or_connect(target_node_addr).await?;
     let mut client = ReplicationClient::new(ctx.clock().clone(), channel.clone());
     let keyspace_timestamps = client.poll_keyspace().await?;
 
@@ -387,7 +386,7 @@ async fn begin_keyspace_sync<S>(
 where
     S: Storage + Send + Sync + 'static,
 {
-    let channel = ctx.network.get_or_connect(Some(target_node_id), target_rpc_addr).await?;
+    let channel = ctx.network.get_or_connect(target_rpc_addr).await?;
     let keyspace = ctx.group.get_or_create_keyspace(&keyspace_name).await;
     let client = ReplicationClient::new(ctx.clock().clone(), channel.clone());
 

--- a/datacake-cluster/src/replication/poller.rs
+++ b/datacake-cluster/src/replication/poller.rs
@@ -272,7 +272,7 @@ where
     let mut tasks = Vec::new();
     for keyspace in diff {
         let permits = permits.clone();
-        let target_node_id = target_node_id.clone();
+        let target_node_id = target_node_id;
         let group = ctx.group.clone();
         let client = ReplicationClient::new(ctx.clock().clone(), channel.clone());
 

--- a/datacake-cluster/src/rpc/chitchat_transport.rs
+++ b/datacake-cluster/src/rpc/chitchat_transport.rs
@@ -116,10 +116,10 @@ impl Socket for GrpcConnection {
         trace!(to = %to, msg = ?msg, "Gossip send");
         let message = msg.serialize_to_vec();
         let source = self.self_addr.serialize_to_vec();
-        
+
         // todo: how do we get access to the ndoe id here?
         let channel =
-            self.network.get_or_connect(None, to).await.map_err(|e| {
+            self.network.get_or_connect(to).await.map_err(|e| {
                 io::Error::new(ErrorKind::ConnectionRefused, e.to_string())
             })?;
 

--- a/datacake-cluster/src/rpc/chitchat_transport.rs
+++ b/datacake-cluster/src/rpc/chitchat_transport.rs
@@ -116,9 +116,10 @@ impl Socket for GrpcConnection {
         trace!(to = %to, msg = ?msg, "Gossip send");
         let message = msg.serialize_to_vec();
         let source = self.self_addr.serialize_to_vec();
-
+        
+        // todo: how do we get access to the ndoe id here?
         let channel =
-            self.network.get_or_connect(to).await.map_err(|e| {
+            self.network.get_or_connect(None, to).await.map_err(|e| {
                 io::Error::new(ErrorKind::ConnectionRefused, e.to_string())
             })?;
 

--- a/datacake-cluster/src/rpc/client.rs
+++ b/datacake-cluster/src/rpc/client.rs
@@ -10,6 +10,7 @@ use tonic::Status;
 
 use crate::core::Document;
 use crate::keyspace::KeyspaceTimestamps;
+use crate::node_identifier::NodeID;
 use crate::rpc::datacake_api;
 use crate::rpc::datacake_api::consistency_api_client::ConsistencyApiClient;
 use crate::rpc::datacake_api::replication_api_client::ReplicationApiClient;
@@ -47,7 +48,7 @@ impl ConsistencyClient {
         &mut self,
         keyspace: impl Into<String>,
         doc: Document,
-        node_id: &str,
+        node_id: NodeID,
         node_addr: SocketAddr,
     ) -> Result<(), Status> {
         let ts = self
@@ -72,7 +73,7 @@ impl ConsistencyClient {
         &mut self,
         keyspace: impl Into<String>,
         docs: impl Iterator<Item = Document>,
-        node_id: &str,
+        node_id: NodeID,
         node_addr: SocketAddr,
     ) -> Result<(), Status> {
         let ts = self

--- a/datacake-cluster/src/rpc/datacake_api.rs
+++ b/datacake-cluster/src/rpc/datacake_api.rs
@@ -75,8 +75,10 @@ pub struct KeyspaceInfo {
     pub timestamp: ::core::option::Option<Timestamp>,
     /// A mapping of a given keyspace and the timestamp of when it was last updated.
     #[prost(map = "string, message", tag = "2")]
-    pub keyspace_timestamps:
-        ::std::collections::HashMap<::prost::alloc::string::String, Timestamp>,
+    pub keyspace_timestamps: ::std::collections::HashMap<
+        ::prost::alloc::string::String,
+        Timestamp,
+    >,
 }
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
@@ -156,8 +158,8 @@ pub struct DocumentMetadata {
 /// Generated client implementations.
 pub mod chitchat_transport_client {
     #![allow(unused_variables, dead_code, missing_docs, clippy::let_unit_value)]
-    use tonic::codegen::http::Uri;
     use tonic::codegen::*;
+    use tonic::codegen::http::Uri;
     #[derive(Debug, Clone)]
     pub struct ChitchatTransportClient<T> {
         inner: tonic::client::Grpc<T>,
@@ -226,12 +228,15 @@ pub mod chitchat_transport_client {
             &mut self,
             request: impl tonic::IntoRequest<super::ChitchatRpcMessage>,
         ) -> Result<tonic::Response<super::Empty>, tonic::Status> {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::new(
-                    tonic::Code::Unknown,
-                    format!("Service was not ready: {}", e.into()),
-                )
-            })?;
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::new(
+                        tonic::Code::Unknown,
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static(
                 "/datacake_api.ChitchatTransport/send_msg",
@@ -243,8 +248,8 @@ pub mod chitchat_transport_client {
 /// Generated client implementations.
 pub mod consistency_api_client {
     #![allow(unused_variables, dead_code, missing_docs, clippy::let_unit_value)]
-    use tonic::codegen::http::Uri;
     use tonic::codegen::*;
+    use tonic::codegen::http::Uri;
     #[derive(Debug, Clone)]
     pub struct ConsistencyApiClient<T> {
         inner: tonic::client::Grpc<T>,
@@ -314,15 +319,19 @@ pub mod consistency_api_client {
             &mut self,
             request: impl tonic::IntoRequest<super::PutPayload>,
         ) -> Result<tonic::Response<super::Timestamp>, tonic::Status> {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::new(
-                    tonic::Code::Unknown,
-                    format!("Service was not ready: {}", e.into()),
-                )
-            })?;
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::new(
+                        tonic::Code::Unknown,
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path =
-                http::uri::PathAndQuery::from_static("/datacake_api.ConsistencyApi/put");
+            let path = http::uri::PathAndQuery::from_static(
+                "/datacake_api.ConsistencyApi/put",
+            );
             self.inner.unary(request.into_request(), path, codec).await
         }
         /// Adds a set of documents to the state.
@@ -330,12 +339,15 @@ pub mod consistency_api_client {
             &mut self,
             request: impl tonic::IntoRequest<super::MultiPutPayload>,
         ) -> Result<tonic::Response<super::Timestamp>, tonic::Status> {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::new(
-                    tonic::Code::Unknown,
-                    format!("Service was not ready: {}", e.into()),
-                )
-            })?;
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::new(
+                        tonic::Code::Unknown,
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static(
                 "/datacake_api.ConsistencyApi/multi_put",
@@ -347,12 +359,15 @@ pub mod consistency_api_client {
             &mut self,
             request: impl tonic::IntoRequest<super::RemovePayload>,
         ) -> Result<tonic::Response<super::Timestamp>, tonic::Status> {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::new(
-                    tonic::Code::Unknown,
-                    format!("Service was not ready: {}", e.into()),
-                )
-            })?;
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::new(
+                        tonic::Code::Unknown,
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static(
                 "/datacake_api.ConsistencyApi/remove",
@@ -364,12 +379,15 @@ pub mod consistency_api_client {
             &mut self,
             request: impl tonic::IntoRequest<super::MultiRemovePayload>,
         ) -> Result<tonic::Response<super::Timestamp>, tonic::Status> {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::new(
-                    tonic::Code::Unknown,
-                    format!("Service was not ready: {}", e.into()),
-                )
-            })?;
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::new(
+                        tonic::Code::Unknown,
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static(
                 "/datacake_api.ConsistencyApi/multi_remove",
@@ -381,12 +399,15 @@ pub mod consistency_api_client {
             &mut self,
             request: impl tonic::IntoRequest<super::BatchPayload>,
         ) -> Result<tonic::Response<super::Timestamp>, tonic::Status> {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::new(
-                    tonic::Code::Unknown,
-                    format!("Service was not ready: {}", e.into()),
-                )
-            })?;
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::new(
+                        tonic::Code::Unknown,
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static(
                 "/datacake_api.ConsistencyApi/apply_batch",
@@ -398,8 +419,8 @@ pub mod consistency_api_client {
 /// Generated client implementations.
 pub mod replication_api_client {
     #![allow(unused_variables, dead_code, missing_docs, clippy::let_unit_value)]
-    use tonic::codegen::http::Uri;
     use tonic::codegen::*;
+    use tonic::codegen::http::Uri;
     #[derive(Debug, Clone)]
     pub struct ReplicationApiClient<T> {
         inner: tonic::client::Grpc<T>,
@@ -469,12 +490,15 @@ pub mod replication_api_client {
             &mut self,
             request: impl tonic::IntoRequest<super::PollPayload>,
         ) -> Result<tonic::Response<super::KeyspaceInfo>, tonic::Status> {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::new(
-                    tonic::Code::Unknown,
-                    format!("Service was not ready: {}", e.into()),
-                )
-            })?;
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::new(
+                        tonic::Code::Unknown,
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static(
                 "/datacake_api.ReplicationApi/poll_keyspace",
@@ -486,12 +510,15 @@ pub mod replication_api_client {
             &mut self,
             request: impl tonic::IntoRequest<super::GetState>,
         ) -> Result<tonic::Response<super::KeyspaceOrSwotSet>, tonic::Status> {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::new(
-                    tonic::Code::Unknown,
-                    format!("Service was not ready: {}", e.into()),
-                )
-            })?;
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::new(
+                        tonic::Code::Unknown,
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static(
                 "/datacake_api.ReplicationApi/get_state",
@@ -503,12 +530,15 @@ pub mod replication_api_client {
             &mut self,
             request: impl tonic::IntoRequest<super::FetchDocs>,
         ) -> Result<tonic::Response<super::FetchedDocs>, tonic::Status> {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::new(
-                    tonic::Code::Unknown,
-                    format!("Service was not ready: {}", e.into()),
-                )
-            })?;
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::new(
+                        tonic::Code::Unknown,
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static(
                 "/datacake_api.ReplicationApi/fetch_docs",
@@ -591,13 +621,15 @@ pub mod chitchat_transport_server {
                 "/datacake_api.ChitchatTransport/send_msg" => {
                     #[allow(non_camel_case_types)]
                     struct send_msgSvc<T: ChitchatTransport>(pub Arc<T>);
-                    impl<T: ChitchatTransport>
-                        tonic::server::UnaryService<super::ChitchatRpcMessage>
-                        for send_msgSvc<T>
-                    {
+                    impl<
+                        T: ChitchatTransport,
+                    > tonic::server::UnaryService<super::ChitchatRpcMessage>
+                    for send_msgSvc<T> {
                         type Response = super::Empty;
-                        type Future =
-                            BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::ChitchatRpcMessage>,
@@ -623,15 +655,19 @@ pub mod chitchat_transport_server {
                         Ok(res)
                     };
                     Box::pin(fut)
-                },
-                _ => Box::pin(async move {
-                    Ok(http::Response::builder()
-                        .status(200)
-                        .header("grpc-status", "12")
-                        .header("content-type", "application/grpc")
-                        .body(empty_body())
-                        .unwrap())
-                }),
+                }
+                _ => {
+                    Box::pin(async move {
+                        Ok(
+                            http::Response::builder()
+                                .status(200)
+                                .header("grpc-status", "12")
+                                .header("content-type", "application/grpc")
+                                .body(empty_body())
+                                .unwrap(),
+                        )
+                    })
+                }
             }
         }
     }
@@ -655,7 +691,8 @@ pub mod chitchat_transport_server {
             write!(f, "{:?}", self.0)
         }
     }
-    impl<T: ChitchatTransport> tonic::server::NamedService for ChitchatTransportServer<T> {
+    impl<T: ChitchatTransport> tonic::server::NamedService
+    for ChitchatTransportServer<T> {
         const NAME: &'static str = "datacake_api.ChitchatTransport";
     }
 }
@@ -754,12 +791,14 @@ pub mod consistency_api_server {
                 "/datacake_api.ConsistencyApi/put" => {
                     #[allow(non_camel_case_types)]
                     struct putSvc<T: ConsistencyApi>(pub Arc<T>);
-                    impl<T: ConsistencyApi>
-                        tonic::server::UnaryService<super::PutPayload> for putSvc<T>
-                    {
+                    impl<
+                        T: ConsistencyApi,
+                    > tonic::server::UnaryService<super::PutPayload> for putSvc<T> {
                         type Response = super::Timestamp;
-                        type Future =
-                            BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::PutPayload>,
@@ -785,17 +824,19 @@ pub mod consistency_api_server {
                         Ok(res)
                     };
                     Box::pin(fut)
-                },
+                }
                 "/datacake_api.ConsistencyApi/multi_put" => {
                     #[allow(non_camel_case_types)]
                     struct multi_putSvc<T: ConsistencyApi>(pub Arc<T>);
-                    impl<T: ConsistencyApi>
-                        tonic::server::UnaryService<super::MultiPutPayload>
-                        for multi_putSvc<T>
-                    {
+                    impl<
+                        T: ConsistencyApi,
+                    > tonic::server::UnaryService<super::MultiPutPayload>
+                    for multi_putSvc<T> {
                         type Response = super::Timestamp;
-                        type Future =
-                            BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::MultiPutPayload>,
@@ -821,17 +862,19 @@ pub mod consistency_api_server {
                         Ok(res)
                     };
                     Box::pin(fut)
-                },
+                }
                 "/datacake_api.ConsistencyApi/remove" => {
                     #[allow(non_camel_case_types)]
                     struct removeSvc<T: ConsistencyApi>(pub Arc<T>);
-                    impl<T: ConsistencyApi>
-                        tonic::server::UnaryService<super::RemovePayload>
-                        for removeSvc<T>
-                    {
+                    impl<
+                        T: ConsistencyApi,
+                    > tonic::server::UnaryService<super::RemovePayload>
+                    for removeSvc<T> {
                         type Response = super::Timestamp;
-                        type Future =
-                            BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::RemovePayload>,
@@ -857,24 +900,27 @@ pub mod consistency_api_server {
                         Ok(res)
                     };
                     Box::pin(fut)
-                },
+                }
                 "/datacake_api.ConsistencyApi/multi_remove" => {
                     #[allow(non_camel_case_types)]
                     struct multi_removeSvc<T: ConsistencyApi>(pub Arc<T>);
-                    impl<T: ConsistencyApi>
-                        tonic::server::UnaryService<super::MultiRemovePayload>
-                        for multi_removeSvc<T>
-                    {
+                    impl<
+                        T: ConsistencyApi,
+                    > tonic::server::UnaryService<super::MultiRemovePayload>
+                    for multi_removeSvc<T> {
                         type Response = super::Timestamp;
-                        type Future =
-                            BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::MultiRemovePayload>,
                         ) -> Self::Future {
                             let inner = self.0.clone();
-                            let fut =
-                                async move { (*inner).multi_remove(request).await };
+                            let fut = async move {
+                                (*inner).multi_remove(request).await
+                            };
                             Box::pin(fut)
                         }
                     }
@@ -894,17 +940,19 @@ pub mod consistency_api_server {
                         Ok(res)
                     };
                     Box::pin(fut)
-                },
+                }
                 "/datacake_api.ConsistencyApi/apply_batch" => {
                     #[allow(non_camel_case_types)]
                     struct apply_batchSvc<T: ConsistencyApi>(pub Arc<T>);
-                    impl<T: ConsistencyApi>
-                        tonic::server::UnaryService<super::BatchPayload>
-                        for apply_batchSvc<T>
-                    {
+                    impl<
+                        T: ConsistencyApi,
+                    > tonic::server::UnaryService<super::BatchPayload>
+                    for apply_batchSvc<T> {
                         type Response = super::Timestamp;
-                        type Future =
-                            BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::BatchPayload>,
@@ -930,15 +978,19 @@ pub mod consistency_api_server {
                         Ok(res)
                     };
                     Box::pin(fut)
-                },
-                _ => Box::pin(async move {
-                    Ok(http::Response::builder()
-                        .status(200)
-                        .header("grpc-status", "12")
-                        .header("content-type", "application/grpc")
-                        .body(empty_body())
-                        .unwrap())
-                }),
+                }
+                _ => {
+                    Box::pin(async move {
+                        Ok(
+                            http::Response::builder()
+                                .status(200)
+                                .header("grpc-status", "12")
+                                .header("content-type", "application/grpc")
+                                .body(empty_body())
+                                .unwrap(),
+                        )
+                    })
+                }
             }
         }
     }
@@ -1051,20 +1103,23 @@ pub mod replication_api_server {
                 "/datacake_api.ReplicationApi/poll_keyspace" => {
                     #[allow(non_camel_case_types)]
                     struct poll_keyspaceSvc<T: ReplicationApi>(pub Arc<T>);
-                    impl<T: ReplicationApi>
-                        tonic::server::UnaryService<super::PollPayload>
-                        for poll_keyspaceSvc<T>
-                    {
+                    impl<
+                        T: ReplicationApi,
+                    > tonic::server::UnaryService<super::PollPayload>
+                    for poll_keyspaceSvc<T> {
                         type Response = super::KeyspaceInfo;
-                        type Future =
-                            BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::PollPayload>,
                         ) -> Self::Future {
                             let inner = self.0.clone();
-                            let fut =
-                                async move { (*inner).poll_keyspace(request).await };
+                            let fut = async move {
+                                (*inner).poll_keyspace(request).await
+                            };
                             Box::pin(fut)
                         }
                     }
@@ -1084,16 +1139,17 @@ pub mod replication_api_server {
                         Ok(res)
                     };
                     Box::pin(fut)
-                },
+                }
                 "/datacake_api.ReplicationApi/get_state" => {
                     #[allow(non_camel_case_types)]
                     struct get_stateSvc<T: ReplicationApi>(pub Arc<T>);
                     impl<T: ReplicationApi> tonic::server::UnaryService<super::GetState>
-                        for get_stateSvc<T>
-                    {
+                    for get_stateSvc<T> {
                         type Response = super::KeyspaceOrSwotSet;
-                        type Future =
-                            BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::GetState>,
@@ -1119,16 +1175,17 @@ pub mod replication_api_server {
                         Ok(res)
                     };
                     Box::pin(fut)
-                },
+                }
                 "/datacake_api.ReplicationApi/fetch_docs" => {
                     #[allow(non_camel_case_types)]
                     struct fetch_docsSvc<T: ReplicationApi>(pub Arc<T>);
                     impl<T: ReplicationApi> tonic::server::UnaryService<super::FetchDocs>
-                        for fetch_docsSvc<T>
-                    {
+                    for fetch_docsSvc<T> {
                         type Response = super::FetchedDocs;
-                        type Future =
-                            BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::FetchDocs>,
@@ -1154,15 +1211,19 @@ pub mod replication_api_server {
                         Ok(res)
                     };
                     Box::pin(fut)
-                },
-                _ => Box::pin(async move {
-                    Ok(http::Response::builder()
-                        .status(200)
-                        .header("grpc-status", "12")
-                        .header("content-type", "application/grpc")
-                        .body(empty_body())
-                        .unwrap())
-                }),
+                }
+                _ => {
+                    Box::pin(async move {
+                        Ok(
+                            http::Response::builder()
+                                .status(200)
+                                .header("grpc-status", "12")
+                                .header("content-type", "application/grpc")
+                                .body(empty_body())
+                                .unwrap(),
+                        )
+                    })
+                }
             }
         }
     }

--- a/datacake-cluster/src/rpc/network.rs
+++ b/datacake-cluster/src/rpc/network.rs
@@ -15,8 +15,6 @@ pub const CONNECT_TIMEOUT_LIMIT: Duration = Duration::from_secs(2);
 #[derive(Clone)]
 pub struct RpcNetworkClient {
     pub(crate) channel: Channel,
-    /// TODO: figure out how to handle sections which done have access to node id
-    pub(crate) node_id: Option<NodeID>,
 }
 
 #[derive(Clone, Default)]
@@ -27,7 +25,7 @@ pub struct RpcNetwork {
 
 impl RpcNetwork {
     /// Attempts to get an already existing connection or creates a new connection.
-    pub async fn get_or_connect(&self, node_id: Option<NodeID>, addr: SocketAddr) -> Result<Channel, Error> {
+    pub async fn get_or_connect(&self, addr: SocketAddr) -> Result<Channel, Error> {
         {
             let guard = self.clients.read();
             if let Some(client) = guard.get(&addr) {
@@ -36,11 +34,11 @@ impl RpcNetwork {
         }
 
         trace!(addr = %addr, "Connect client to network.");
-        self.connect(node_id, addr).await
+        self.connect(addr).await
     }
 
     /// Connects to a given address and adds it to the clients.
-    pub async fn connect(&self,  node_id: Option<NodeID>, addr: SocketAddr) -> Result<Channel, Error> {
+    pub async fn connect(&self, addr: SocketAddr) -> Result<Channel, Error> {
         let uri = format!("http://{}", addr);
         let channel = Endpoint::from_str(&uri)
             .unwrap()
@@ -51,13 +49,18 @@ impl RpcNetwork {
 
         {
             let mut guard = self.clients.write();
-            guard.insert(addr, RpcNetworkClient { channel: channel.clone(), node_id: if let Some(id) = node_id { Some(id) } else { None } });
+            guard.insert(
+                addr,
+                RpcNetworkClient {
+                    channel: channel.clone(),
+                },
+            );
         }
 
         Ok(channel)
     }
     /// Attempts to get an already existing connection or creates a new connection.
-    pub fn get_or_connect_lazy(&self, node_id: Option<NodeID>, addr: SocketAddr) -> Channel {
+    pub fn get_or_connect_lazy(&self, addr: SocketAddr) -> Channel {
         {
             let guard = self.clients.read();
             if let Some(client) = guard.get(&addr) {
@@ -65,11 +68,11 @@ impl RpcNetwork {
             }
         }
 
-        self.connect_lazy(node_id, addr)
+        self.connect_lazy(addr)
     }
 
     /// Creates a new endpoint channel which connects lazily to the node.
-    pub fn connect_lazy(&self, node_id: Option<NodeID>, addr: SocketAddr) -> Channel {
+    pub fn connect_lazy(&self, addr: SocketAddr) -> Channel {
         let uri = format!("http://{}", addr);
         let channel = Endpoint::from_str(&uri)
             .unwrap()
@@ -79,7 +82,12 @@ impl RpcNetwork {
 
         {
             let mut guard = self.clients.write();
-            guard.insert(addr,RpcNetworkClient { channel: channel.clone(), node_id: if let Some(id) = node_id { Some(id) } else { None } });
+            guard.insert(
+                addr,
+                RpcNetworkClient {
+                    channel: channel.clone(),
+                },
+            );
         }
 
         channel

--- a/datacake-cluster/src/rpc/network.rs
+++ b/datacake-cluster/src/rpc/network.rs
@@ -7,8 +7,6 @@ use std::time::Duration;
 use parking_lot::RwLock;
 use tonic::transport::{Channel, Endpoint, Error};
 
-use crate::node_identifier::NodeID;
-
 pub const TIMEOUT_LIMIT: Duration = Duration::from_secs(4);
 pub const CONNECT_TIMEOUT_LIMIT: Duration = Duration::from_secs(2);
 

--- a/datacake-cluster/src/rpc/server/consistency_impl.rs
+++ b/datacake-cluster/src/rpc/server/consistency_impl.rs
@@ -51,7 +51,7 @@ where
                 Ok(nid) => nid,
                 Err(err) => return Err(Status::internal(format!("{:#?}", err))),
             };
-            let remote_rpc_channel = self.network.get_or_connect_lazy(Some(nid), remote_addr);
+            let remote_rpc_channel = self.network.get_or_connect_lazy(remote_addr);
 
             Some(PutContext {
                 progress: ProgressTracker::default(),

--- a/datacake-cluster/src/rpc/server/consistency_impl.rs
+++ b/datacake-cluster/src/rpc/server/consistency_impl.rs
@@ -1,4 +1,3 @@
-use std::borrow::Cow;
 use std::marker::PhantomData;
 use std::net::SocketAddr;
 use std::str::FromStr;

--- a/datacake-cluster/src/rpc/server/consistency_impl.rs
+++ b/datacake-cluster/src/rpc/server/consistency_impl.rs
@@ -46,7 +46,7 @@ where
                 ))
             })?;
 
-            let remote_rpc_channel = self.network.get_or_connect_lazy(remote_addr);
+            let remote_rpc_channel = self.network.get_or_connect_lazy(Some(info.node_id.clone()), remote_addr);
 
             Some(PutContext {
                 progress: ProgressTracker::default(),

--- a/datacake-cluster/src/storage.rs
+++ b/datacake-cluster/src/storage.rs
@@ -368,9 +368,7 @@ pub mod test_suite {
         run_test_suite(MemStore::default()).await
     }
 
-    pub async fn run_test_suite<S: Storage + Send + Sync + 'static>(
-        storage: S,
-    ) {
+    pub async fn run_test_suite<S: Storage + Send + Sync + 'static>(storage: S) {
         let mut clock = HLCTimestamp::new(get_unix_timestamp_ms(), 0, 0);
         info!("Starting test suite for storage: {}", type_name::<S>());
 
@@ -395,7 +393,7 @@ pub mod test_suite {
 
         static KEYSPACE: &str = "first-keyspace";
         let check_list = vec![KEYSPACE.to_string()];
-        
+
         let res = storage.iter_metadata(KEYSPACE).await;
         if let Err(e) = res {
             panic!(
@@ -723,7 +721,6 @@ pub mod test_suite {
             .await
             .expect("Mark document as tombstone.");
 
-
         let res = storage.get(KEYSPACE, 2).await;
         assert!(
             res.is_ok(),
@@ -750,7 +747,6 @@ pub mod test_suite {
             )
             .await
             .expect("Merk documents as tombstones");
-
 
         let res = storage
             .multi_get(KEYSPACE, [1, 2, 3].into_iter())

--- a/datacake-cluster/src/storage.rs
+++ b/datacake-cluster/src/storage.rs
@@ -10,6 +10,7 @@ use datacake_crdt::{HLCTimestamp, Key};
 use tonic::transport::Channel;
 
 use crate::core::Document;
+use crate::node_identifier::NodeID;
 
 #[derive(Debug)]
 /// A utility for tracking the progress a task has made.
@@ -89,7 +90,7 @@ pub struct PutContext {
     pub(crate) progress: ProgressTracker,
 
     // Info relating to the remote node.
-    pub(crate) remote_node_id: Cow<'static, str>,
+    pub(crate) remote_node_id: NodeID,
     pub(crate) remote_addr: SocketAddr,
     pub(crate) remote_rpc_channel: Channel,
 }
@@ -106,8 +107,8 @@ impl PutContext {
 
     #[inline]
     /// The unique ID of the remote node.
-    pub fn remote_node_id(&self) -> &str {
-        self.remote_node_id.as_ref()
+    pub fn remote_node_id(&self) -> NodeID {
+        self.remote_node_id
     }
 
     #[inline]

--- a/datacake-cluster/src/storage.rs
+++ b/datacake-cluster/src/storage.rs
@@ -1,4 +1,3 @@
-use std::borrow::Cow;
 use std::error::Error;
 use std::net::SocketAddr;
 use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};

--- a/datacake-cluster/tests/basic_connect.rs
+++ b/datacake-cluster/tests/basic_connect.rs
@@ -15,9 +15,9 @@ async fn test_basic_connect() -> anyhow::Result<()> {
 
     let addr = "127.0.0.1:8000".parse::<SocketAddr>().unwrap();
     let connection_cfg = ConnectionConfig::new(addr, addr, Vec::<String>::new());
-
+    let node_id = age::x25519::Identity::generate();
     let cluster = DatacakeCluster::connect(
-        "node-1",
+        node_id,
         connection_cfg,
         MemStore::default(),
         DCAwareSelector::default(),

--- a/datacake-cluster/tests/basic_connect.rs
+++ b/datacake-cluster/tests/basic_connect.rs
@@ -11,6 +11,7 @@ use datacake_cluster::{
 
 #[tokio::test]
 async fn test_basic_connect() -> anyhow::Result<()> {
+    std::env::set_var("RUST_LOG", "trace,sled=info");
     let _ = tracing_subscriber::fmt::try_init();
 
     let addr = "127.0.0.1:8000".parse::<SocketAddr>().unwrap();

--- a/datacake-cluster/tests/dynamic_membership.rs
+++ b/datacake-cluster/tests/dynamic_membership.rs
@@ -14,6 +14,9 @@ use datacake_cluster::{
 #[tokio::test]
 pub async fn test_member_join() -> anyhow::Result<()> {
     let _ = tracing_subscriber::fmt::try_init();
+    let node_1_id = age::x25519::Identity::generate();
+    let node_2_id = age::x25519::Identity::generate();
+    let node_3_id = age::x25519::Identity::generate();
 
     let node_1_addr = "127.0.0.1:8018".parse::<SocketAddr>().unwrap();
     let node_2_addr = "127.0.0.1:8019".parse::<SocketAddr>().unwrap();
@@ -35,7 +38,7 @@ pub async fn test_member_join() -> anyhow::Result<()> {
     );
 
     let node_1 = DatacakeCluster::connect(
-        "node-1",
+        node_1_id,
         node_1_connection_cfg,
         InstrumentedStorage(MemStore::default()),
         DCAwareSelector::default(),
@@ -44,7 +47,7 @@ pub async fn test_member_join() -> anyhow::Result<()> {
     .await
     .expect("Connect node.");
     let node_2 = DatacakeCluster::connect(
-        "node-2",
+        node_2_id,
         node_2_connection_cfg,
         InstrumentedStorage(MemStore::default()),
         DCAwareSelector::default(),
@@ -105,7 +108,7 @@ pub async fn test_member_join() -> anyhow::Result<()> {
     assert_eq!(doc.data, Bytes::from_static(b"Hello, world from node-2"));
 
     let node_3 = DatacakeCluster::connect(
-        "node-3",
+        node_3_id,
         node_3_connection_cfg,
         InstrumentedStorage(MemStore::default()),
         DCAwareSelector::default(),
@@ -170,6 +173,11 @@ pub async fn test_member_join_sled() -> anyhow::Result<()> {
     use datacake_sled::SledStorage;
     let _ = tracing_subscriber::fmt::try_init();
 
+    let node_1_id = age::x25519::Identity::generate();
+    let node_2_id = age::x25519::Identity::generate();
+    let node_3_id = age::x25519::Identity::generate();
+
+
     let node_1_addr = "127.0.0.1:8018".parse::<SocketAddr>().unwrap();
     let node_2_addr = "127.0.0.1:8019".parse::<SocketAddr>().unwrap();
     let node_3_addr = "127.0.0.1:8020".parse::<SocketAddr>().unwrap();
@@ -190,7 +198,7 @@ pub async fn test_member_join_sled() -> anyhow::Result<()> {
     );
 
     let node_1 = DatacakeCluster::connect(
-        "node-1",
+        node_1_id,
         node_1_connection_cfg,
         InstrumentedStorage(SledStorage::open_temporary().unwrap()),
         DCAwareSelector::default(),
@@ -199,7 +207,7 @@ pub async fn test_member_join_sled() -> anyhow::Result<()> {
     .await
     .expect("Connect node.");
     let node_2 = DatacakeCluster::connect(
-        "node-2",
+        node_2_id,
         node_2_connection_cfg,
         InstrumentedStorage(SledStorage::open_temporary().unwrap()),
         DCAwareSelector::default(),
@@ -260,7 +268,7 @@ pub async fn test_member_join_sled() -> anyhow::Result<()> {
     assert_eq!(doc.data, Bytes::from_static(b"Hello, world from node-2"));
 
     let node_3 = DatacakeCluster::connect(
-        "node-3",
+        node_3_id,
         node_3_connection_cfg,
         InstrumentedStorage(MemStore::default()),
         DCAwareSelector::default(),
@@ -325,6 +333,12 @@ pub async fn test_member_join_sled() -> anyhow::Result<()> {
 pub async fn test_member_leave() -> anyhow::Result<()> {
     let _ = tracing_subscriber::fmt::try_init();
 
+    let node_1_id = age::x25519::Identity::generate();
+    let node_2_id = age::x25519::Identity::generate();
+    let node_3_id = age::x25519::Identity::generate();
+
+
+
     let node_1_addr = "127.0.0.1:8021".parse::<SocketAddr>().unwrap();
     let node_2_addr = "127.0.0.1:8022".parse::<SocketAddr>().unwrap();
     let node_3_addr = "127.0.0.1:8023".parse::<SocketAddr>().unwrap();
@@ -345,7 +359,7 @@ pub async fn test_member_leave() -> anyhow::Result<()> {
     );
 
     let node_1 = DatacakeCluster::connect(
-        "node-1",
+        node_1_id,
         node_1_connection_cfg,
         InstrumentedStorage(MemStore::default()),
         DCAwareSelector::default(),
@@ -354,7 +368,7 @@ pub async fn test_member_leave() -> anyhow::Result<()> {
     .await
     .expect("Connect node.");
     let node_2 = DatacakeCluster::connect(
-        "node-2",
+        node_2_id,
         node_2_connection_cfg,
         InstrumentedStorage(MemStore::default()),
         DCAwareSelector::default(),
@@ -363,7 +377,7 @@ pub async fn test_member_leave() -> anyhow::Result<()> {
     .await
     .expect("Connect node.");
     let node_3 = DatacakeCluster::connect(
-        "node-3",
+        node_3_id,
         node_3_connection_cfg.clone(),
         InstrumentedStorage(MemStore::default()),
         DCAwareSelector::default(),

--- a/datacake-cluster/tests/dynamic_membership.rs
+++ b/datacake-cluster/tests/dynamic_membership.rs
@@ -4,7 +4,11 @@ use std::time::Duration;
 use bytes::Bytes;
 use datacake_cluster::test_utils::{InstrumentedStorage, MemStore};
 use datacake_cluster::{
-    ClusterOptions, ConnectionConfig, Consistency, DCAwareSelector, DatacakeCluster,
+    ClusterOptions,
+    ConnectionConfig,
+    Consistency,
+    DCAwareSelector,
+    DatacakeCluster,
 };
 
 #[tokio::test(flavor = "multi_thread")]
@@ -227,11 +231,17 @@ pub async fn test_member_join_sled() -> anyhow::Result<()> {
     .expect("Connect node.");
 
     node_1
-        .wait_for_nodes(&[node_2_id.to_public().to_string()], Duration::from_secs(30))
+        .wait_for_nodes(
+            &[node_2_id.to_public().to_string()],
+            Duration::from_secs(30),
+        )
         .await
         .expect("Nodes should connect within timeout.");
     node_2
-        .wait_for_nodes(&[node_1_id.to_public().to_string()], Duration::from_secs(30))
+        .wait_for_nodes(
+            &[node_1_id.to_public().to_string()],
+            Duration::from_secs(30),
+        )
         .await
         .expect("Nodes should connect within timeout.");
 
@@ -287,7 +297,13 @@ pub async fn test_member_join_sled() -> anyhow::Result<()> {
     .await
     .expect("Connect node.");
     node_3
-        .wait_for_nodes(&[node_1_id.to_public().to_string(), node_2_id.to_public().to_string()], Duration::from_secs(30))
+        .wait_for_nodes(
+            &[
+                node_1_id.to_public().to_string(),
+                node_2_id.to_public().to_string(),
+            ],
+            Duration::from_secs(30),
+        )
         .await
         .expect("Nodes should connect within timeout.");
     let node_3_handle = node_3.handle_with_keyspace("my-keyspace");
@@ -347,7 +363,6 @@ pub async fn test_member_leave() -> anyhow::Result<()> {
     let node_2_id = age::x25519::Identity::generate();
     let node_3_id = age::x25519::Identity::generate();
 
-
     let node_1_addr = "127.0.0.1:8021".parse::<SocketAddr>().unwrap();
     let node_2_addr = "127.0.0.1:8022".parse::<SocketAddr>().unwrap();
     let node_3_addr = "127.0.0.1:8023".parse::<SocketAddr>().unwrap();
@@ -396,15 +411,33 @@ pub async fn test_member_leave() -> anyhow::Result<()> {
     .expect("Connect node.");
 
     node_1
-        .wait_for_nodes(&[node_2_id.to_public().to_string(), node_3_id.to_public().to_string()], Duration::from_secs(30))
+        .wait_for_nodes(
+            &[
+                node_2_id.to_public().to_string(),
+                node_3_id.to_public().to_string(),
+            ],
+            Duration::from_secs(30),
+        )
         .await
         .expect("Nodes should connect within timeout.");
     node_2
-        .wait_for_nodes(&[node_3_id.to_public().to_string(), node_1_id.to_public().to_string()], Duration::from_secs(30))
+        .wait_for_nodes(
+            &[
+                node_3_id.to_public().to_string(),
+                node_1_id.to_public().to_string(),
+            ],
+            Duration::from_secs(30),
+        )
         .await
         .expect("Nodes should connect within timeout.");
     node_3
-        .wait_for_nodes(&[node_2_id.to_public().to_string(), node_1_id.to_public().to_string()], Duration::from_secs(30))
+        .wait_for_nodes(
+            &[
+                node_2_id.to_public().to_string(),
+                node_1_id.to_public().to_string(),
+            ],
+            Duration::from_secs(30),
+        )
         .await
         .expect("Nodes should connect within timeout.");
 

--- a/datacake-cluster/tests/multi_node_cluster.rs
+++ b/datacake-cluster/tests/multi_node_cluster.rs
@@ -654,10 +654,13 @@ async fn test_async_operations() -> anyhow::Result<()> {
 async fn connect_cluster(
     addrs: [SocketAddr; 3],
 ) -> [DatacakeCluster<InstrumentedStorage<MemStore>>; 3] {
+    let node_1_id = age::x25519::Identity::generate();
+    let node_2_id = age::x25519::Identity::generate();
+    let node_3_id = age::x25519::Identity::generate();
     dbg!(
-        crc32fast::hash("node-1".as_bytes()),
-        crc32fast::hash("node-2".as_bytes()),
-        crc32fast::hash("node-3".as_bytes())
+        crc32fast::hash(node_1_id.to_public().to_string().as_bytes()),
+        crc32fast::hash(node_2_id.to_public().to_string().as_bytes()),
+        crc32fast::hash(node_3_id.to_public().to_string().as_bytes())
     );
 
     let node_1_connection_cfg = ConnectionConfig::new(
@@ -677,7 +680,7 @@ async fn connect_cluster(
     );
 
     let node_1 = DatacakeCluster::connect(
-        "node-1",
+        node_1_id.clone(),
         node_1_connection_cfg,
         InstrumentedStorage(MemStore::default()),
         DCAwareSelector::default(),
@@ -686,7 +689,7 @@ async fn connect_cluster(
     .await
     .expect("Connect node.");
     let node_2 = DatacakeCluster::connect(
-        "node-2",
+        node_2_id.clone(),
         node_2_connection_cfg,
         InstrumentedStorage(MemStore::default()),
         DCAwareSelector::default(),
@@ -695,7 +698,7 @@ async fn connect_cluster(
     .await
     .expect("Connect node.");
     let node_3 = DatacakeCluster::connect(
-        "node-3",
+        node_3_id.clone(),
         node_3_connection_cfg,
         InstrumentedStorage(MemStore::default()),
         DCAwareSelector::default(),
@@ -705,15 +708,15 @@ async fn connect_cluster(
     .expect("Connect node.");
 
     node_1
-        .wait_for_nodes(&["node-2", "node-3"], Duration::from_secs(30))
+        .wait_for_nodes(&[&node_2_id.to_public().to_string(), &node_3_id.to_public().to_string()], Duration::from_secs(30))
         .await
         .expect("Nodes should connect within timeout.");
     node_2
-        .wait_for_nodes(&["node-3", "node-1"], Duration::from_secs(30))
+        .wait_for_nodes(&[&node_3_id.to_public().to_string(), &node_1_id.to_public().to_string()], Duration::from_secs(30))
         .await
         .expect("Nodes should connect within timeout.");
     node_3
-        .wait_for_nodes(&["node-2", "node-1"], Duration::from_secs(30))
+        .wait_for_nodes(&[&node_2_id.to_public().to_string(), &node_1_id.to_public().to_string()], Duration::from_secs(30))
         .await
         .expect("Nodes should connect within timeout.");
 
@@ -749,12 +752,14 @@ async fn connect_sled_cluster(
     addrs: [SocketAddr; 3],
 ) -> [DatacakeCluster<InstrumentedStorage<datacake_sled::SledStorage>>; 3] {
     use datacake_sled::SledStorage;
+    let node_1_id = age::x25519::Identity::generate();
+    let node_2_id = age::x25519::Identity::generate();
+    let node_3_id = age::x25519::Identity::generate();
     dbg!(
-        crc32fast::hash("node-1".as_bytes()),
-        crc32fast::hash("node-2".as_bytes()),
-        crc32fast::hash("node-3".as_bytes())
+        crc32fast::hash(node_1_id.to_public().to_string().as_bytes()),
+        crc32fast::hash(node_2_id.to_public().to_string().as_bytes()),
+        crc32fast::hash(node_3_id.to_public().to_string().as_bytes())
     );
-
     let node_1_connection_cfg = ConnectionConfig::new(
         addrs[0],
         addrs[0],
@@ -772,7 +777,7 @@ async fn connect_sled_cluster(
     );
 
     let node_1 = DatacakeCluster::connect(
-        "node-1",
+        node_1_id.clone(),
         node_1_connection_cfg,
         InstrumentedStorage(SledStorage::open_temporary().unwrap()),
         DCAwareSelector::default(),
@@ -781,7 +786,7 @@ async fn connect_sled_cluster(
     .await
     .expect("Connect node.");
     let node_2 = DatacakeCluster::connect(
-        "node-2",
+        node_2_id.clone(),
         node_2_connection_cfg,
         InstrumentedStorage(SledStorage::open_temporary().unwrap()),
         DCAwareSelector::default(),
@@ -790,7 +795,7 @@ async fn connect_sled_cluster(
     .await
     .expect("Connect node.");
     let node_3 = DatacakeCluster::connect(
-        "node-3",
+        node_3_id.clone(),
         node_3_connection_cfg,
         InstrumentedStorage(SledStorage::open_temporary().unwrap()),
         DCAwareSelector::default(),
@@ -800,15 +805,15 @@ async fn connect_sled_cluster(
     .expect("Connect node.");
 
     node_1
-        .wait_for_nodes(&["node-2", "node-3"], Duration::from_secs(30))
+        .wait_for_nodes(&[ &node_2_id.to_public().to_string(),  &node_3_id.to_public().to_string()], Duration::from_secs(30))
         .await
         .expect("Nodes should connect within timeout.");
     node_2
-        .wait_for_nodes(&["node-3", "node-1"], Duration::from_secs(30))
+        .wait_for_nodes(&[ &node_3_id.to_public().to_string(),  &node_1_id.to_public().to_string()], Duration::from_secs(30))
         .await
         .expect("Nodes should connect within timeout.");
     node_3
-        .wait_for_nodes(&["node-2", "node-1"], Duration::from_secs(30))
+        .wait_for_nodes(&[ &node_2_id.to_public().to_string(),  &node_1_id.to_public().to_string()], Duration::from_secs(30))
         .await
         .expect("Nodes should connect within timeout.");
 

--- a/datacake-cluster/tests/multi_node_cluster.rs
+++ b/datacake-cluster/tests/multi_node_cluster.rs
@@ -708,15 +708,33 @@ async fn connect_cluster(
     .expect("Connect node.");
 
     node_1
-        .wait_for_nodes(&[&node_2_id.to_public().to_string(), &node_3_id.to_public().to_string()], Duration::from_secs(30))
+        .wait_for_nodes(
+            &[
+                &node_2_id.to_public().to_string(),
+                &node_3_id.to_public().to_string(),
+            ],
+            Duration::from_secs(30),
+        )
         .await
         .expect("Nodes should connect within timeout.");
     node_2
-        .wait_for_nodes(&[&node_3_id.to_public().to_string(), &node_1_id.to_public().to_string()], Duration::from_secs(30))
+        .wait_for_nodes(
+            &[
+                &node_3_id.to_public().to_string(),
+                &node_1_id.to_public().to_string(),
+            ],
+            Duration::from_secs(30),
+        )
         .await
         .expect("Nodes should connect within timeout.");
     node_3
-        .wait_for_nodes(&[&node_2_id.to_public().to_string(), &node_1_id.to_public().to_string()], Duration::from_secs(30))
+        .wait_for_nodes(
+            &[
+                &node_2_id.to_public().to_string(),
+                &node_1_id.to_public().to_string(),
+            ],
+            Duration::from_secs(30),
+        )
         .await
         .expect("Nodes should connect within timeout.");
 
@@ -805,15 +823,33 @@ async fn connect_sled_cluster(
     .expect("Connect node.");
 
     node_1
-        .wait_for_nodes(&[ &node_2_id.to_public().to_string(),  &node_3_id.to_public().to_string()], Duration::from_secs(30))
+        .wait_for_nodes(
+            &[
+                &node_2_id.to_public().to_string(),
+                &node_3_id.to_public().to_string(),
+            ],
+            Duration::from_secs(30),
+        )
         .await
         .expect("Nodes should connect within timeout.");
     node_2
-        .wait_for_nodes(&[ &node_3_id.to_public().to_string(),  &node_1_id.to_public().to_string()], Duration::from_secs(30))
+        .wait_for_nodes(
+            &[
+                &node_3_id.to_public().to_string(),
+                &node_1_id.to_public().to_string(),
+            ],
+            Duration::from_secs(30),
+        )
         .await
         .expect("Nodes should connect within timeout.");
     node_3
-        .wait_for_nodes(&[ &node_2_id.to_public().to_string(),  &node_1_id.to_public().to_string()], Duration::from_secs(30))
+        .wait_for_nodes(
+            &[
+                &node_2_id.to_public().to_string(),
+                &node_1_id.to_public().to_string(),
+            ],
+            Duration::from_secs(30),
+        )
         .await
         .expect("Nodes should connect within timeout.");
 

--- a/datacake-cluster/tests/multiple_keyspace.rs
+++ b/datacake-cluster/tests/multiple_keyspace.rs
@@ -17,12 +17,12 @@ static KEYSPACE_3: &str = "my-third-keyspace";
 #[tokio::test]
 async fn test_single_node() -> anyhow::Result<()> {
     let _ = tracing_subscriber::fmt::try_init();
-
+    let node_1_id = age::x25519::Identity::generate();
     let node_addr = "127.0.0.1:8014".parse::<SocketAddr>().unwrap();
     let connection_cfg =
         ConnectionConfig::new(node_addr, node_addr, Vec::<String>::new());
     let node = DatacakeCluster::connect(
-        "node-1",
+        node_1_id.clone(),
         connection_cfg,
         InstrumentedStorage(MemStore::default()),
         DCAwareSelector::default(),
@@ -71,7 +71,9 @@ async fn test_single_node() -> anyhow::Result<()> {
 #[tokio::test]
 async fn test_multi_node() -> anyhow::Result<()> {
     let _ = tracing_subscriber::fmt::try_init();
-
+    let node_1_id = age::x25519::Identity::generate();
+    let node_2_id = age::x25519::Identity::generate();
+    let node_3_id = age::x25519::Identity::generate();
     let node_1_addr = "127.0.0.1:8015".parse::<SocketAddr>().unwrap();
     let node_2_addr = "127.0.0.1:8016".parse::<SocketAddr>().unwrap();
     let node_3_addr = "127.0.0.1:8017".parse::<SocketAddr>().unwrap();
@@ -92,7 +94,7 @@ async fn test_multi_node() -> anyhow::Result<()> {
     );
 
     let node_1 = DatacakeCluster::connect(
-        "node-1",
+        node_1_id.clone(),
         node_1_connection_cfg,
         InstrumentedStorage(MemStore::default()),
         DCAwareSelector::default(),
@@ -101,7 +103,7 @@ async fn test_multi_node() -> anyhow::Result<()> {
     .await
     .expect("Connect node.");
     let node_2 = DatacakeCluster::connect(
-        "node-2",
+        node_2_id.clone(),
         node_2_connection_cfg,
         InstrumentedStorage(MemStore::default()),
         DCAwareSelector::default(),
@@ -110,7 +112,7 @@ async fn test_multi_node() -> anyhow::Result<()> {
     .await
     .expect("Connect node.");
     let node_3 = DatacakeCluster::connect(
-        "node-3",
+        node_3_id.clone(),
         node_3_connection_cfg,
         InstrumentedStorage(MemStore::default()),
         DCAwareSelector::default(),
@@ -120,15 +122,15 @@ async fn test_multi_node() -> anyhow::Result<()> {
     .expect("Connect node.");
 
     node_1
-        .wait_for_nodes(&["node-2", "node-3"], Duration::from_secs(30))
+        .wait_for_nodes(&[&node_2_id.to_public().to_string(), &node_3_id.to_public().to_string()], Duration::from_secs(30))
         .await
         .expect("Nodes should connect within timeout.");
     node_2
-        .wait_for_nodes(&["node-3", "node-1"], Duration::from_secs(30))
+        .wait_for_nodes(&[&node_3_id.to_public().to_string(), &node_1_id.to_public().to_string()], Duration::from_secs(30))
         .await
         .expect("Nodes should connect within timeout.");
     node_3
-        .wait_for_nodes(&["node-2", "node-1"], Duration::from_secs(30))
+        .wait_for_nodes(&[&node_2_id.to_public().to_string(), &node_1_id.to_public().to_string()], Duration::from_secs(30))
         .await
         .expect("Nodes should connect within timeout.");
 
@@ -175,7 +177,9 @@ async fn test_multi_node() -> anyhow::Result<()> {
 async fn test_multi_node_sled() -> anyhow::Result<()> {
     use datacake_sled::SledStorage;
     let _ = tracing_subscriber::fmt::try_init();
-
+    let node_1_id = age::x25519::Identity::generate();
+    let node_2_id = age::x25519::Identity::generate();
+    let node_3_id = age::x25519::Identity::generate();
     let node_1_addr = "127.0.0.1:8015".parse::<SocketAddr>().unwrap();
     let node_2_addr = "127.0.0.1:8016".parse::<SocketAddr>().unwrap();
     let node_3_addr = "127.0.0.1:8017".parse::<SocketAddr>().unwrap();
@@ -196,7 +200,7 @@ async fn test_multi_node_sled() -> anyhow::Result<()> {
     );
 
     let node_1 = DatacakeCluster::connect(
-        "node-1",
+        node_1_id.clone(),
         node_1_connection_cfg,
         InstrumentedStorage(SledStorage::open_temporary().unwrap()),
         DCAwareSelector::default(),
@@ -205,7 +209,7 @@ async fn test_multi_node_sled() -> anyhow::Result<()> {
     .await
     .expect("Connect node.");
     let node_2 = DatacakeCluster::connect(
-        "node-2",
+        node_2_id.clone(),
         node_2_connection_cfg,
         InstrumentedStorage(SledStorage::open_temporary().unwrap()),
         DCAwareSelector::default(),
@@ -214,7 +218,7 @@ async fn test_multi_node_sled() -> anyhow::Result<()> {
     .await
     .expect("Connect node.");
     let node_3 = DatacakeCluster::connect(
-        "node-3",
+        node_3_id.clone(),
         node_3_connection_cfg,
         InstrumentedStorage(SledStorage::open_temporary().unwrap()),
         DCAwareSelector::default(),

--- a/datacake-cluster/tests/multiple_keyspace.rs
+++ b/datacake-cluster/tests/multiple_keyspace.rs
@@ -122,15 +122,33 @@ async fn test_multi_node() -> anyhow::Result<()> {
     .expect("Connect node.");
 
     node_1
-        .wait_for_nodes(&[&node_2_id.to_public().to_string(), &node_3_id.to_public().to_string()], Duration::from_secs(30))
+        .wait_for_nodes(
+            &[
+                &node_2_id.to_public().to_string(),
+                &node_3_id.to_public().to_string(),
+            ],
+            Duration::from_secs(30),
+        )
         .await
         .expect("Nodes should connect within timeout.");
     node_2
-        .wait_for_nodes(&[&node_3_id.to_public().to_string(), &node_1_id.to_public().to_string()], Duration::from_secs(30))
+        .wait_for_nodes(
+            &[
+                &node_3_id.to_public().to_string(),
+                &node_1_id.to_public().to_string(),
+            ],
+            Duration::from_secs(30),
+        )
         .await
         .expect("Nodes should connect within timeout.");
     node_3
-        .wait_for_nodes(&[&node_2_id.to_public().to_string(), &node_1_id.to_public().to_string()], Duration::from_secs(30))
+        .wait_for_nodes(
+            &[
+                &node_2_id.to_public().to_string(),
+                &node_1_id.to_public().to_string(),
+            ],
+            Duration::from_secs(30),
+        )
         .await
         .expect("Nodes should connect within timeout.");
 

--- a/datacake-cluster/tests/single_node_cluster.rs
+++ b/datacake-cluster/tests/single_node_cluster.rs
@@ -16,12 +16,12 @@ static KEYSPACE: &str = "my-keyspace";
 #[tokio::test]
 async fn test_single_node_cluster() -> anyhow::Result<()> {
     let _ = tracing_subscriber::fmt::try_init();
-
+    let node_1_id = age::x25519::Identity::generate();
     let addr = "127.0.0.1:8001".parse::<SocketAddr>().unwrap();
     let connection_cfg = ConnectionConfig::new(addr, addr, Vec::<String>::new());
 
     let cluster = DatacakeCluster::connect(
-        "node-1",
+        node_1_id,
         connection_cfg,
         MemStore::default(),
         DCAwareSelector::default(),
@@ -93,11 +93,12 @@ async fn test_single_node_cluster() -> anyhow::Result<()> {
 async fn test_single_node_cluster_with_keyspace_handle() -> anyhow::Result<()> {
     let _ = tracing_subscriber::fmt::try_init();
 
+    let node_1_id = age::x25519::Identity::generate();
     let addr = "127.0.0.1:8002".parse::<SocketAddr>().unwrap();
     let connection_cfg = ConnectionConfig::new(addr, addr, Vec::<String>::new());
 
     let cluster = DatacakeCluster::connect(
-        "node-1",
+        node_1_id,
         connection_cfg,
         MemStore::default(),
         DCAwareSelector::default(),
@@ -167,9 +168,9 @@ async fn test_single_node_cluster_bulk_op() -> anyhow::Result<()> {
 
     let addr = "127.0.0.1:8003".parse::<SocketAddr>().unwrap();
     let connection_cfg = ConnectionConfig::new(addr, addr, Vec::<String>::new());
-
+    let node_1_id = age::x25519::Identity::generate();
     let cluster = DatacakeCluster::connect(
-        "node-1",
+        node_1_id,
         connection_cfg,
         MemStore::default(),
         DCAwareSelector::default(),
@@ -254,9 +255,9 @@ async fn test_single_node_cluster_bulk_op_with_keyspace_handle() -> anyhow::Resu
 
     let addr = "127.0.0.1:8004".parse::<SocketAddr>().unwrap();
     let connection_cfg = ConnectionConfig::new(addr, addr, Vec::<String>::new());
-
+    let node_1_id = age::x25519::Identity::generate();
     let cluster = DatacakeCluster::connect(
-        "node-1",
+        node_1_id,
         connection_cfg,
         MemStore::default(),
         DCAwareSelector::default(),

--- a/datacake-sled/Cargo.toml
+++ b/datacake-sled/Cargo.toml
@@ -20,3 +20,4 @@ log = "0.4"
 [dev-dependencies]
 tracing = "0.1.37"
 tracing-subscriber = "0.3.16"
+age = "0.9"

--- a/datacake-sled/tests/basic_cluster.rs
+++ b/datacake-sled/tests/basic_cluster.rs
@@ -16,7 +16,8 @@ static KEYSPACE: &str = "sqlite-store";
 async fn test_basic_sled_cluster() -> Result<()> {
     std::env::set_var("RUST_LOG", "debug,h2=info,tower=info,sled=info");
     let _ = tracing_subscriber::fmt::try_init();
-
+    let node_1_id = age::x25519::Identity::generate();
+    let node_2_id = age::x25519::Identity::generate();
     let store_1 = SledStorage::open_temporary()?;
     let store_2 = SledStorage::open_temporary()?;
 
@@ -28,7 +29,7 @@ async fn test_basic_sled_cluster() -> Result<()> {
         ConnectionConfig::new(addr_2, addr_2, vec!["127.0.0.1:9000".to_string()]);
 
     let cluster_1 = DatacakeCluster::connect(
-        "node-1",
+        node_1_id.clone(),
         connection_cfg_1,
         store_1,
         DCAwareSelector::default(),
@@ -37,7 +38,7 @@ async fn test_basic_sled_cluster() -> Result<()> {
     .await?;
 
     let cluster_2 = DatacakeCluster::connect(
-        "node-2",
+        node_2_id.clone(),
         connection_cfg_2,
         store_2,
         DCAwareSelector::default(),

--- a/datacake-sqlite/Cargo.toml
+++ b/datacake-sqlite/Cargo.toml
@@ -34,3 +34,4 @@ tracing-subscriber = "0.3.16"
 
 uuid = { version = "1", features = ["v4"] }
 datacake-cluster = { version = "0.1", path = "../datacake-cluster", features = ["test-utils"] }
+age = "0.9"

--- a/datacake-sqlite/tests/basic_cluster.rs
+++ b/datacake-sqlite/tests/basic_cluster.rs
@@ -15,14 +15,14 @@ static KEYSPACE: &str = "sqlite-store";
 #[tokio::test]
 async fn test_basic_sqlite_cluster() -> Result<()> {
     let _ = tracing_subscriber::fmt::try_init();
-
+    let node_1_id = age::x25519::Identity::generate();
     let store = SqliteStorage::open_in_memory().await?;
 
     let addr = "127.0.0.1:9000".parse::<SocketAddr>().unwrap();
     let connection_cfg = ConnectionConfig::new(addr, addr, Vec::<String>::new());
 
     let cluster = DatacakeCluster::connect(
-        "node-1",
+        node_1_id.clone(),
         connection_cfg,
         store,
         DCAwareSelector::default(),

--- a/examples/replicated-kv/Cargo.toml
+++ b/examples/replicated-kv/Cargo.toml
@@ -31,5 +31,6 @@ tower-http = { version = "0.3.0", features = [
     "map-request-body", "util"
 ] }
 jemallocator = {version = "0.5.0"}
+age = "0.9"
 [dev-dependencies]
 datacake = { version = "0.1", path = "../..", features = ["test-utils"] }

--- a/examples/replicated-kv/README.md
+++ b/examples/replicated-kv/README.md
@@ -5,8 +5,10 @@ This is a nice little example of a KV store implemented as two basic HTTP endpoi
 ## Running
 ### Single node cluster
 ```shell
-cargo run --release -- --node-id "node-1" --data-dir "./my-data"
+cargo run --release -- --data-dir "./my-data"
 ```
+
+The node identifiers for this example are randomly generated x25519 keypairs
 
 This will spawn a single node with an ID of `node-1` and store the data in the `my-data` directory which will be
 created if it doesn't already exist.
@@ -14,9 +16,9 @@ created if it doesn't already exist.
 
 ### 3 node cluster
 ```shell
-cargo run --release -- --node-id "node-1" --data-dir "./my-data/node-1-data --rest-listen-addr 127.0.0.1:8000 --cluster-listen-addr 127.0.0.1:8001 --seed 127.0.0.1:8003 --seed 127.0.0.1:8005"
-cargo run --release -- --node-id "node-2" --data-dir "./my-data/node-2-data --rest-listen-addr 127.0.0.1:8002 --cluster-listen-addr 127.0.0.1:8003 --seed 127.0.0.1:8001 --seed 127.0.0.1:8005"
-cargo run --release -- --node-id "node-3" --data-dir "./my-data/node-3-data --rest-listen-addr 127.0.0.1:8004 --cluster-listen-addr 127.0.0.1:8005 --seed 127.0.0.1:8001 --seed 127.0.0.1:8003"
+cargo run --release -- --data-dir "./my-data/node-1-data --rest-listen-addr 127.0.0.1:8000 --cluster-listen-addr 127.0.0.1:8001 --seed 127.0.0.1:8003 --seed 127.0.0.1:8005"
+cargo run --release -- --data-dir "./my-data/node-2-data --rest-listen-addr 127.0.0.1:8002 --cluster-listen-addr 127.0.0.1:8003 --seed 127.0.0.1:8001 --seed 127.0.0.1:8005"
+cargo run --release -- --data-dir "./my-data/node-3-data --rest-listen-addr 127.0.0.1:8004 --cluster-listen-addr 127.0.0.1:8005 --seed 127.0.0.1:8001 --seed 127.0.0.1:8003"
 ```
 
 This will start a local 3 node cluster, for simplicity we've set the seeds to be each node's peers rather although this does

--- a/examples/replicated-kv/src/main.rs
+++ b/examples/replicated-kv/src/main.rs
@@ -30,13 +30,15 @@ async fn main() -> Result<()> {
     let args: Args = Args::parse();
     let storage =
         datacake_sled::SledStorage::open(sled::Config::new().path(&args.data_dir))?;
+    let node_1_id = age::x25519::Identity::generate();
+    info!("using node_id {}", node_1_id.to_public().to_string());
     let connection_cfg = ConnectionConfig::new(
         args.cluster_listen_addr,
         args.public_addr.unwrap_or(args.cluster_listen_addr),
         args.seeds.into_iter(),
     );
     let cluster = DatacakeCluster::connect(
-        args.node_id,
+        node_1_id,
         connection_cfg,
         storage,
         DCAwareSelector::default(),
@@ -85,10 +87,6 @@ async fn handle_error(error: BoxError) -> impl IntoResponse {
 #[derive(Parser, Debug)]
 #[command(version, about, long_about = None)]
 pub struct Args {
-    #[arg(long)]
-    /// The unique ID of the node.
-    node_id: String,
-
     #[arg(long = "seed")]
     /// The set of seed nodes.
     ///


### PR DESCRIPTION
Replaces all node identifiers with cryptographic rage/x25519 keys. Additionally the node identifier public key is stored as a `[u8; 62]`, so passing around the identifiers will be cheaper.